### PR TITLE
feat: add service landing pages for OpenClaw, Paperclip, and 4 new offerings

### DIFF
--- a/src/app/(app)/(main)/_components/header.tsx
+++ b/src/app/(app)/(main)/_components/header.tsx
@@ -1,6 +1,6 @@
 'use client'
 import Link from 'next/link'
-import { ChevronRight, Menu, X } from 'lucide-react'
+import { ChevronDown, ChevronRight, Menu, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import React from 'react'
 import { motion } from 'motion/react'
@@ -9,9 +9,22 @@ import { Logo } from '@/components/assets/logo'
 import { usePathname } from 'next/navigation'
 import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
 
-const menuItems = [
+type MenuItem = {
+    name: string
+    href: string
+    children?: { name: string; href: string }[]
+}
+
+const menuItems: MenuItem[] = [
     { name: 'Home', href: '/' },
-    { name: 'Services', href: '/services' },
+    {
+        name: 'Services',
+        href: '/services',
+        children: [
+            { name: 'OpenClaw Setup', href: '/services/openclaw' },
+            { name: 'Paperclip AI Company', href: '/services/paperclip' },
+        ],
+    },
     { name: 'FAQ', href: '/#faq' },
 ]
 
@@ -96,12 +109,27 @@ export const HeroHeader = () => {
                                 transition={{ duration: 0.2 }}>
                                 <ul className="flex gap-8 text-sm">
                                     {menuItems.map((item) => (
-                                        <li key={item.href}>
+                                        <li key={item.href} className="relative group/nav">
                                             <Link
                                                 href={item.href}
-                                                className="text-muted-foreground hover:text-accent-foreground block duration-150">
+                                                className="text-muted-foreground hover:text-accent-foreground flex items-center gap-1 duration-150">
                                                 <span>{item.name}</span>
+                                                {item.children && <ChevronDown className="h-3 w-3 transition-transform duration-150 group-hover/nav:rotate-180" />}
                                             </Link>
+                                            {item.children && (
+                                                <div className="absolute left-0 top-full pt-2 opacity-0 pointer-events-none group-hover/nav:opacity-100 group-hover/nav:pointer-events-auto transition-opacity duration-150">
+                                                    <div className="bg-background rounded-xl border shadow-md py-1 min-w-[180px]">
+                                                        {item.children.map((child) => (
+                                                            <Link
+                                                                key={child.href}
+                                                                href={child.href}
+                                                                className="block px-4 py-2 text-sm text-muted-foreground hover:text-accent-foreground hover:bg-muted/50 duration-150">
+                                                                {child.name}
+                                                            </Link>
+                                                        ))}
+                                                    </div>
+                                                </div>
+                                            )}
                                         </li>
                                     ))}
                                 </ul>
@@ -123,10 +151,25 @@ export const HeroHeader = () => {
                                                 <Link
                                                     href={item.href}
                                                     className="text-muted-foreground hover:text-accent-foreground block duration-150"
-                                                    onClick={() => setMenuState(false)} // Close menu on link click
+                                                    onClick={() => setMenuState(false)}
                                                 >
                                                     <span>{item.name}</span>
                                                 </Link>
+                                                {item.children && (
+                                                    <ul className="mt-3 ml-4 space-y-3">
+                                                        {item.children.map((child) => (
+                                                            <li key={child.href}>
+                                                                <Link
+                                                                    href={child.href}
+                                                                    className="text-muted-foreground/70 hover:text-accent-foreground block text-sm duration-150"
+                                                                    onClick={() => setMenuState(false)}
+                                                                >
+                                                                    {child.name}
+                                                                </Link>
+                                                            </li>
+                                                        ))}
+                                                    </ul>
+                                                )}
                                             </li>
                                         ))}
                                     </ul>

--- a/src/app/(app)/(main)/_components/header.tsx
+++ b/src/app/(app)/(main)/_components/header.tsx
@@ -1,209 +1,224 @@
-'use client'
-import Link from 'next/link'
-import { ChevronDown, ChevronRight, Menu, X } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import React from 'react'
-import { motion } from 'motion/react'
-import { cn } from '@/lib/utils'
-import { Logo } from '@/components/assets/logo'
-import { usePathname } from 'next/navigation'
-import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
+"use client";
+import { ChevronDown, ChevronRight, Menu, X } from "lucide-react";
+import { motion } from "motion/react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React from "react";
+import { Logo } from "@/components/assets/logo";
+import { ScheduleCallModal } from "@/components/modals/schedule-call-modal";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type MenuItem = {
-    name: string
-    href: string
-    children?: { name: string; href: string }[]
-}
+  name: string;
+  href: string;
+  children?: { name: string; href: string }[];
+};
 
 const menuItems: MenuItem[] = [
-    { name: 'Home', href: '/' },
-    {
-        name: 'Services',
-        href: '/services',
-        children: [
-            { name: 'OpenClaw Setup', href: '/services/openclaw' },
-            { name: 'Paperclip AI Company', href: '/services/paperclip' },
-        ],
-    },
-    { name: 'FAQ', href: '/#faq' },
-]
+  { name: "Home", href: "/" },
+  {
+    name: "Services",
+    href: "/services",
+    children: [
+      { name: "OpenClaw Setup", href: "/services/openclaw" },
+      { name: "Paperclip AI Company", href: "/services/paperclip" },
+    ],
+  },
+  { name: "FAQ", href: "/#faq" },
+];
 
 export const HeroHeader = () => {
-    const pathname = usePathname()
-    const isNotHome = pathname !== '/'
-    const [menuState, setMenuState] = React.useState(false)
-    const [hasScrolled, setHasScrolled] = React.useState(false)
-    const [elementsVisible, setElementsVisible] = React.useState(false)
+  const pathname = usePathname();
+  const isNotHome = pathname !== "/";
+  const [menuState, setMenuState] = React.useState(false);
+  const [hasScrolled, setHasScrolled] = React.useState(false);
+  const [elementsVisible, setElementsVisible] = React.useState(false);
 
-    React.useEffect(() => {
-        const handleScroll = () => {
-            if (isNotHome) {
-                setHasScrolled(true)
-                setElementsVisible(true)
-                return
-            }
+  React.useEffect(() => {
+    const handleScroll = () => {
+      if (isNotHome) {
+        setHasScrolled(true);
+        setElementsVisible(true);
+        return;
+      }
 
-            const scrollY = window.scrollY
-            setHasScrolled(scrollY > 50)
-            setElementsVisible(scrollY > 100)
-        }
+      const scrollY = window.scrollY;
+      setHasScrolled(scrollY > 50);
+      setElementsVisible(scrollY > 100);
+    };
 
-        const handleClickOutside = (event: MouseEvent) => {
-            if (menuState && !(event.target as Element).closest('nav')) {
-                setMenuState(false)
-            }
-        }
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuState && !(event.target as Element).closest("nav")) {
+        setMenuState(false);
+      }
+    };
 
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === 'Escape' && menuState) {
-                setMenuState(false)
-            }
-        }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && menuState) {
+        setMenuState(false);
+      }
+    };
 
-        window.addEventListener('scroll', handleScroll)
-        document.addEventListener('click', handleClickOutside)
-        document.addEventListener('keydown', handleKeyDown)
-        handleScroll() // check on initial render
+    window.addEventListener("scroll", handleScroll);
+    document.addEventListener("click", handleClickOutside);
+    document.addEventListener("keydown", handleKeyDown);
+    handleScroll(); // check on initial render
 
-        return () => {
-            window.removeEventListener('scroll', handleScroll)
-            document.removeEventListener('click', handleClickOutside)
-            document.removeEventListener('keydown', handleKeyDown)
-        }
-    }, [menuState, isNotHome])
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      document.removeEventListener("click", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuState, isNotHome]);
 
-    return (
-        <header>
-            <nav
-                aria-label="Primary"
-                className="group fixed z-20 w-full pt-2 px-1">
-                <div className={cn('mx-auto max-w-7xl rounded-3xl border border-border/0 px-6 transition-all duration-200 group-hover:border-border lg:px-12', hasScrolled && 'bg-background/50 backdrop-blur-2xl border-border/30')}>
-                    <motion.div
-                        key={1}
-                        className={cn('relative flex flex-wrap items-center justify-between gap-6 py-3 duration-200 lg:gap-0 lg:py-6', hasScrolled && 'lg:py-4')}>
-                        <div className="flex w-full items-center justify-between gap-12 lg:w-auto">
-                            <Link
-                                href="/"
-                                aria-label="home"
-                                className="flex items-center space-x-2">
-                                <Logo />
-                            </Link>
+  return (
+    <header>
+      <nav aria-label="Primary" className="group fixed z-20 w-full pt-2 px-1">
+        <div
+          className={cn(
+            "mx-auto max-w-7xl rounded-3xl border border-border/0 px-6 transition-all duration-200 group-hover:border-border lg:px-12",
+            hasScrolled && "bg-background/50 backdrop-blur-2xl border-border/30"
+          )}
+        >
+          <motion.div
+            key={1}
+            className={cn(
+              "relative flex flex-wrap items-center justify-between gap-6 py-3 duration-200 lg:gap-0 lg:py-6",
+              hasScrolled && "lg:py-4"
+            )}
+          >
+            <div className="flex w-full items-center justify-between gap-12 lg:w-auto">
+              <Link href="/" aria-label="home" className="flex items-center space-x-2">
+                <Logo />
+              </Link>
 
-                            <motion.button
-                                onClick={() => setMenuState(!menuState)}
-                                aria-label={menuState ? 'Close Menu' : 'Open Menu'}
-                                aria-expanded={menuState}
-                                aria-controls="primary-menu"
-                                className="relative z-20 -m-2.5 -mr-4 block cursor-pointer p-2.5 lg:hidden"
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                transition={{ duration: 0.2 }}>
-                                <Menu className={cn("m-auto size-6 duration-200", menuState ? "rotate-180 scale-0 opacity-0" : "rotate-0 scale-100 opacity-100")} />
-                                <X className={cn("absolute inset-0 m-auto size-6 -rotate-180 scale-0 opacity-0 duration-200", menuState ? "rotate-0 scale-100 opacity-100" : "-rotate-180 scale-0 opacity-0")} />
-                            </motion.button>
+              <motion.button
+                onClick={() => setMenuState(!menuState)}
+                aria-label={menuState ? "Close Menu" : "Open Menu"}
+                aria-expanded={menuState}
+                aria-controls="primary-menu"
+                className="relative z-20 -m-2.5 -mr-4 block cursor-pointer p-2.5 lg:hidden"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ duration: 0.2 }}
+              >
+                <Menu
+                  className={cn(
+                    "m-auto size-6 duration-200",
+                    menuState ? "rotate-180 scale-0 opacity-0" : "rotate-0 scale-100 opacity-100"
+                  )}
+                />
+                <X
+                  className={cn(
+                    "absolute inset-0 m-auto size-6 -rotate-180 scale-0 opacity-0 duration-200",
+                    menuState ? "rotate-0 scale-100 opacity-100" : "-rotate-180 scale-0 opacity-0"
+                  )}
+                />
+              </motion.button>
 
-                            <motion.div
-                                className="hidden lg:flex lg:items-center lg:gap-6"
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: elementsVisible ? 1 : 0 }}
-                                transition={{ duration: 0.2 }}>
-                                <ul className="flex gap-8 text-sm">
-                                    {menuItems.map((item) => (
-                                        <li key={item.href} className="relative group/nav">
-                                            <Link
-                                                href={item.href}
-                                                className="text-muted-foreground hover:text-accent-foreground flex items-center gap-1 duration-150">
-                                                <span>{item.name}</span>
-                                                {item.children && <ChevronDown className="h-3 w-3 transition-transform duration-150 group-hover/nav:rotate-180" />}
-                                            </Link>
-                                            {item.children && (
-                                                <div className="absolute left-0 top-full pt-2 opacity-0 pointer-events-none group-hover/nav:opacity-100 group-hover/nav:pointer-events-auto transition-opacity duration-150">
-                                                    <div className="bg-background rounded-xl border shadow-md py-1 min-w-[180px]">
-                                                        {item.children.map((child) => (
-                                                            <Link
-                                                                key={child.href}
-                                                                href={child.href}
-                                                                className="block px-4 py-2 text-sm text-muted-foreground hover:text-accent-foreground hover:bg-muted/50 duration-150">
-                                                                {child.name}
-                                                            </Link>
-                                                        ))}
-                                                    </div>
-                                                </div>
-                                            )}
-                                        </li>
-                                    ))}
-                                </ul>
-                            </motion.div>
-                        </div>
-
-                        {menuState && (
-                            <motion.div
-                                className="bg-background mb-6 block w-full flex-wrap items-center justify-end space-y-8 rounded-3xl border p-6 shadow-2xl shadow-zinc-300/20 md:flex-nowrap lg:hidden"
-                                initial={{ opacity: 0, y: -20 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: -20 }}
-                                transition={{ duration: 0.2 }}
-                            >
-                                <div className="lg:hidden">
-                                    <ul id="primary-menu" className="space-y-6 text-base">
-                                        {menuItems.map((item) => (
-                                            <li key={item.href}>
-                                                <Link
-                                                    href={item.href}
-                                                    className="text-muted-foreground hover:text-accent-foreground block duration-150"
-                                                    onClick={() => setMenuState(false)}
-                                                >
-                                                    <span>{item.name}</span>
-                                                </Link>
-                                                {item.children && (
-                                                    <ul className="mt-3 ml-4 space-y-3">
-                                                        {item.children.map((child) => (
-                                                            <li key={child.href}>
-                                                                <Link
-                                                                    href={child.href}
-                                                                    className="text-muted-foreground/70 hover:text-accent-foreground block text-sm duration-150"
-                                                                    onClick={() => setMenuState(false)}
-                                                                >
-                                                                    {child.name}
-                                                                </Link>
-                                                            </li>
-                                                        ))}
-                                                    </ul>
-                                                )}
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </div>
-                                <div className="flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit">
-                                    <ScheduleCallModal
-                                        trigger={
-                                            <Button
-                                                className="rounded-full pl-5 pr-3 text-base"
-                                            >
-                                                <span className="text-nowrap">Book now</span>
-                                                <ChevronRight className="ml-1" />
-                                            </Button>
-                                        }
-                                    />
-                                </div>
-                            </motion.div>
+              <motion.div
+                className="hidden lg:flex lg:items-center lg:gap-6"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: elementsVisible ? 1 : 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <ul className="flex gap-8 text-sm">
+                  {menuItems.map((item) => (
+                    <li key={item.href} className="relative group/nav">
+                      <Link
+                        href={item.href}
+                        className="text-muted-foreground hover:text-accent-foreground flex items-center gap-1 duration-150"
+                      >
+                        <span>{item.name}</span>
+                        {item.children && (
+                          <ChevronDown className="h-3 w-3 transition-transform duration-150 group-hover/nav:rotate-180" />
                         )}
-                        <div className="hidden lg:flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button
-                                        className="rounded-full pl-5 pr-3 text-base"
-                                    >
-                                        <span className="text-nowrap">Book now</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
+                      </Link>
+                      {item.children && (
+                        <div className="absolute left-0 top-full pt-2 opacity-0 pointer-events-none group-hover/nav:opacity-100 group-hover/nav:pointer-events-auto transition-opacity duration-150">
+                          <div className="bg-background rounded-xl border shadow-md py-1 min-w-[180px]">
+                            {item.children.map((child) => (
+                              <Link
+                                key={child.href}
+                                href={child.href}
+                                className="block px-4 py-2 text-sm text-muted-foreground hover:text-accent-foreground hover:bg-muted/50 duration-150"
+                              >
+                                {child.name}
+                              </Link>
+                            ))}
+                          </div>
                         </div>
-                    </motion.div>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </motion.div>
+            </div>
 
+            {menuState && (
+              <motion.div
+                className="bg-background mb-6 block w-full flex-wrap items-center justify-end space-y-8 rounded-3xl border p-6 shadow-2xl shadow-zinc-300/20 md:flex-nowrap lg:hidden"
+                initial={{ opacity: 0, y: -20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="lg:hidden">
+                  <ul id="primary-menu" className="space-y-6 text-base">
+                    {menuItems.map((item) => (
+                      <li key={item.href}>
+                        <Link
+                          href={item.href}
+                          className="text-muted-foreground hover:text-accent-foreground block duration-150"
+                          onClick={() => setMenuState(false)}
+                        >
+                          <span>{item.name}</span>
+                        </Link>
+                        {item.children && (
+                          <ul className="mt-3 ml-4 space-y-3">
+                            {item.children.map((child) => (
+                              <li key={child.href}>
+                                <Link
+                                  href={child.href}
+                                  className="text-muted-foreground/70 hover:text-accent-foreground block text-sm duration-150"
+                                  onClick={() => setMenuState(false)}
+                                >
+                                  {child.name}
+                                </Link>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
                 </div>
-            </nav>
-        </header>
-    )
-}
+                <div className="flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit">
+                  <ScheduleCallModal
+                    trigger={
+                      <Button className="rounded-full pl-5 pr-3 text-base">
+                        <span className="text-nowrap">Book now</span>
+                        <ChevronRight className="ml-1" />
+                      </Button>
+                    }
+                  />
+                </div>
+              </motion.div>
+            )}
+            <div className="hidden lg:flex w-full flex-col space-y-3 sm:flex-row sm:gap-3 sm:space-y-0 md:w-fit">
+              <ScheduleCallModal
+                trigger={
+                  <Button className="rounded-full pl-5 pr-3 text-base">
+                    <span className="text-nowrap">Book now</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
+            </div>
+          </motion.div>
+        </div>
+      </nav>
+    </header>
+  );
+};

--- a/src/app/(app)/(main)/services/openclaw/page.tsx
+++ b/src/app/(app)/(main)/services/openclaw/page.tsx
@@ -1,309 +1,358 @@
-import type { Metadata } from 'next'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
-import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
-import { ChevronRight, Check, ArrowLeft } from 'lucide-react'
-import { routes } from '@/config/routes'
-import { constructMetadata } from '@/config/metadata'
+import { ArrowLeft, Check, ChevronRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ScheduleCallModal } from "@/components/modals/schedule-call-modal";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { constructMetadata } from "@/config/metadata";
+import { routes } from "@/config/routes";
 
 export const metadata: Metadata = constructMetadata({
-    title: 'OpenClaw Setup & Deployment | Build And Serve',
-    description:
-        'Deploy AI agent orchestration with OpenClaw. We handle architecture, configuration, agent design, deployment, and training. $5K–$15K project-based.',
-})
+  title: "OpenClaw Setup & Deployment | Build And Serve",
+  description:
+    "Deploy AI agent orchestration with OpenClaw. We handle architecture, configuration, agent design, deployment, and training. $5K–$15K project-based.",
+});
 
 const steps = [
-    {
-        number: '01',
-        title: 'Discovery',
-        body: '60-minute call to understand your use case, your team, and what you want your agents doing. We\'ll tell you honestly whether OpenClaw is the right fit or if something simpler would work.',
-    },
-    {
-        number: '02',
-        title: 'Architecture & Design',
-        body: 'We design your agent topology — roles, communication patterns, data flows, security model. You review and sign off before we build anything.',
-    },
-    {
-        number: '03',
-        title: 'Build & Deploy',
-        body: 'We configure OpenClaw, build your custom agents, set up monitoring and alerting, and deploy to your infrastructure. Typical timeline: 2–4 weeks.',
-    },
-    {
-        number: '04',
-        title: 'Training & Handoff',
-        body: 'Your team gets hands-on training. We cover day-to-day management, adding new agents, troubleshooting, and extending the system. Plus 30 days of support after handoff.',
-    },
-]
+  {
+    number: "01",
+    title: "Discovery",
+    body: "60-minute call to understand your use case, your team, and what you want your agents doing. We'll tell you honestly whether OpenClaw is the right fit or if something simpler would work.",
+  },
+  {
+    number: "02",
+    title: "Architecture & Design",
+    body: "We design your agent topology — roles, communication patterns, data flows, security model. You review and sign off before we build anything.",
+  },
+  {
+    number: "03",
+    title: "Build & Deploy",
+    body: "We configure OpenClaw, build your custom agents, set up monitoring and alerting, and deploy to your infrastructure. Typical timeline: 2–4 weeks.",
+  },
+  {
+    number: "04",
+    title: "Training & Handoff",
+    body: "Your team gets hands-on training. We cover day-to-day management, adding new agents, troubleshooting, and extending the system. Plus 30 days of support after handoff.",
+  },
+];
 
 const benefits = [
-    {
-        title: 'Architecture That Holds Up',
-        body: 'Most agent deployments fail because the architecture was wrong from the start. We design your agent topology based on what actually works in production, not what looks good in a demo.',
-    },
-    {
-        title: 'Deployed in Weeks, Not Months',
-        body: 'A typical OpenClaw deployment takes 2–4 weeks from kickoff to production. We know the critical path and where teams waste time.',
-    },
-    {
-        title: 'You Own Everything',
-        body: 'No vendor lock-in, no proprietary wrapper. Your OpenClaw instance runs on your infrastructure, your accounts, your control.',
-    },
-    {
-        title: '30 Days of Post-Launch Support',
-        body: 'The first month after deployment is when the real questions come up. Bug fixes, configuration adjustments, agent tuning. We\'re there for it.',
-    },
-]
+  {
+    title: "Architecture That Holds Up",
+    body: "Most agent deployments fail because the architecture was wrong from the start. We design your agent topology based on what actually works in production, not what looks good in a demo.",
+  },
+  {
+    title: "Deployed in Weeks, Not Months",
+    body: "A typical OpenClaw deployment takes 2–4 weeks from kickoff to production. We know the critical path and where teams waste time.",
+  },
+  {
+    title: "You Own Everything",
+    body: "No vendor lock-in, no proprietary wrapper. Your OpenClaw instance runs on your infrastructure, your accounts, your control.",
+  },
+  {
+    title: "30 Days of Post-Launch Support",
+    body: "The first month after deployment is when the real questions come up. Bug fixes, configuration adjustments, agent tuning. We're there for it.",
+  },
+];
 
 const packages = [
-    {
-        name: 'Starter',
-        price: '$5,000–$7,500',
-        description: 'Single workflow, up to 3 agents, standard deployment',
-        features: ['Architecture design', 'Up to 3 custom agents', 'Standard deployment', 'Team training', '30 days post-launch support'],
-    },
-    {
-        name: 'Professional',
-        price: '$7,500–$12,000',
-        description: 'Multi-workflow, up to 8 agents, custom agent development',
-        features: ['Everything in Starter', 'Up to 8 custom agents', 'Multi-workflow orchestration', 'Custom agent development', 'Advanced monitoring'],
-        featured: true,
-    },
-    {
-        name: 'Enterprise',
-        price: '$12,000–$15,000+',
-        description: 'Complex orchestration, unlimited agents, dedicated support',
-        features: ['Everything in Professional', 'Unlimited agents', 'Complex orchestration', 'Dedicated support contact', 'Optional ongoing retainer'],
-    },
-]
+  {
+    name: "Starter",
+    price: "$5,000–$7,500",
+    description: "Single workflow, up to 3 agents, standard deployment",
+    features: [
+      "Architecture design",
+      "Up to 3 custom agents",
+      "Standard deployment",
+      "Team training",
+      "30 days post-launch support",
+    ],
+  },
+  {
+    name: "Professional",
+    price: "$7,500–$12,000",
+    description: "Multi-workflow, up to 8 agents, custom agent development",
+    features: [
+      "Everything in Starter",
+      "Up to 8 custom agents",
+      "Multi-workflow orchestration",
+      "Custom agent development",
+      "Advanced monitoring",
+    ],
+    featured: true,
+  },
+  {
+    name: "Enterprise",
+    price: "$12,000–$15,000+",
+    description: "Complex orchestration, unlimited agents, dedicated support",
+    features: [
+      "Everything in Professional",
+      "Unlimited agents",
+      "Complex orchestration",
+      "Dedicated support contact",
+      "Optional ongoing retainer",
+    ],
+  },
+];
 
 const faqs = [
-    {
-        id: 'faq-1',
-        question: 'What is OpenClaw?',
-        answer: 'OpenClaw is an open-source AI agent orchestration platform. It lets you deploy multiple AI agents that work together on tasks — coordinating, sharing context, and producing output that no single agent could handle alone. Think of it as the infrastructure layer for running AI teams.',
-    },
-    {
-        id: 'faq-2',
-        question: 'Do I need technical staff to manage OpenClaw after setup?',
-        answer: 'Someone on your team should be comfortable with basic system administration. We train your team during handoff, and the 30-day support period covers the initial learning curve. For ongoing management without internal technical staff, ask about our managed service.',
-    },
-    {
-        id: 'faq-3',
-        question: 'How long does a typical deployment take?',
-        answer: 'Two to four weeks from kickoff to production, depending on complexity. A single-workflow deployment with a few agents is on the faster end. Complex multi-agent systems with custom development take longer.',
-    },
-    {
-        id: 'faq-4',
-        question: 'Can I add more agents later?',
-        answer: "Yes. We design the architecture so adding agents later doesn't require rebuilding what's already there. You can add them yourself after training, or bring us back for more complex additions.",
-    },
-    {
-        id: 'faq-5',
-        question: 'How is this different from just using ChatGPT or Claude directly?',
-        answer: 'Direct AI usage is one person talking to one model. OpenClaw orchestration is multiple specialized agents coordinating on complex tasks — with monitoring, failure handling, and quality controls. It\'s the difference between asking someone a question and having a team work on a project.',
-    },
-]
+  {
+    id: "faq-1",
+    question: "What is OpenClaw?",
+    answer:
+      "OpenClaw is an open-source AI agent orchestration platform. It lets you deploy multiple AI agents that work together on tasks — coordinating, sharing context, and producing output that no single agent could handle alone. Think of it as the infrastructure layer for running AI teams.",
+  },
+  {
+    id: "faq-2",
+    question: "Do I need technical staff to manage OpenClaw after setup?",
+    answer:
+      "Someone on your team should be comfortable with basic system administration. We train your team during handoff, and the 30-day support period covers the initial learning curve. For ongoing management without internal technical staff, ask about our managed service.",
+  },
+  {
+    id: "faq-3",
+    question: "How long does a typical deployment take?",
+    answer:
+      "Two to four weeks from kickoff to production, depending on complexity. A single-workflow deployment with a few agents is on the faster end. Complex multi-agent systems with custom development take longer.",
+  },
+  {
+    id: "faq-4",
+    question: "Can I add more agents later?",
+    answer:
+      "Yes. We design the architecture so adding agents later doesn't require rebuilding what's already there. You can add them yourself after training, or bring us back for more complex additions.",
+  },
+  {
+    id: "faq-5",
+    question: "How is this different from just using ChatGPT or Claude directly?",
+    answer:
+      "Direct AI usage is one person talking to one model. OpenClaw orchestration is multiple specialized agents coordinating on complex tasks — with monitoring, failure handling, and quality controls. It's the difference between asking someone a question and having a team work on a project.",
+  },
+];
 
 export default function OpenClawPage() {
-    return (
-        <div className="min-h-screen">
-            {/* Back nav */}
-            <div className="mx-auto max-w-5xl px-6 pt-8">
-                <Link
-                    href={routes.services}
-                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                >
-                    <ArrowLeft className="h-4 w-4" />
-                    All services
-                </Link>
+  return (
+    <div className="min-h-screen">
+      {/* Back nav */}
+      <div className="mx-auto max-w-5xl px-6 pt-8">
+        <Link
+          href={routes.services}
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          All services
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
+              OpenClaw Setup & Deployment
+            </p>
+            <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
+              Deploy AI Agent Teams That Actually Work
+            </h1>
+            <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
+              We set up OpenClaw agent orchestration for your business — architecture, deployment,
+              training. Your agents coordinating on real tasks in weeks, not months.
+            </p>
+            <p className="mt-4 text-sm text-muted-foreground">Starting at $5,000</p>
+            <div className="mt-10">
+              <ScheduleCallModal
+                trigger={
+                  <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
+                    <span className="text-nowrap">Book a discovery call</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
             </div>
-
-            {/* Hero */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="max-w-2xl">
-                        <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">OpenClaw Setup & Deployment</p>
-                        <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
-                            Deploy AI Agent Teams That Actually Work
-                        </h1>
-                        <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
-                            We set up OpenClaw agent orchestration for your business — architecture, deployment, training. Your agents coordinating on real tasks in weeks, not months.
-                        </p>
-                        <p className="mt-4 text-sm text-muted-foreground">Starting at $5,000</p>
-                        <div className="mt-10">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
-                                        <span className="text-nowrap">Book a discovery call</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            {/* Context */}
-            <section className="py-16 md:py-24 bg-muted/30">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="max-w-3xl">
-                        <h2 className="text-balance text-3xl font-semibold md:text-4xl">We Build Agent Systems. This Is What We Do.</h2>
-                        <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
-                            <p>
-                                We didn't learn OpenClaw from a tutorial. We've built agent orchestration tools, shipped them to production, and run our own multi-agent teams daily. When we deploy OpenClaw for you, we're drawing on problems we've already solved on our own systems.
-                            </p>
-                            <p>
-                                Juno, Lacy Shell, our own internal agent teams all run on these same patterns. We know where the configuration gets tricky, which agent designs hold up under real workloads, and how to keep the whole system from falling over on day two.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            {/* Benefits */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
-                    <div className="mt-12 grid gap-8 md:grid-cols-2">
-                        {benefits.map((benefit, i) => (
-                            <div key={i} className="space-y-3">
-                                <h3 className="text-lg font-semibold">{benefit.title}</h3>
-                                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
-                            </div>
-                        ))}
-                    </div>
-                    <div className="mt-12 rounded-2xl border bg-card p-8">
-                        <h3 className="font-semibold">Every engagement includes:</h3>
-                        <ul className="mt-4 space-y-2">
-                            {[
-                                'Architecture review and agent design',
-                                'Full OpenClaw deployment (infrastructure, configuration, security, monitoring)',
-                                'Custom agent development for your specific workflows',
-                                'Training for your team on managing and extending the system',
-                                '30 days of post-deployment support',
-                            ].map((item) => (
-                                <li key={item} className="flex items-start gap-3 text-sm">
-                                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                                    <span className="text-muted-foreground">{item}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                </div>
-            </section>
-
-            {/* How it works */}
-            <section className="py-16 md:py-24 bg-muted/30">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
-                    <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
-                        {steps.map((step) => (
-                            <div key={step.number} className="flex gap-8 p-8">
-                                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">{step.number}</p>
-                                <div>
-                                    <h3 className="font-semibold text-lg">{step.title}</h3>
-                                    <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            {/* Pricing */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
-                    <p className="mt-4 text-muted-foreground">All packages include architecture design, deployment, team training, and 30 days post-launch support.</p>
-                    <div className="mt-12 grid gap-6 md:grid-cols-3">
-                        {packages.map((pkg) => (
-                            <Card
-                                key={pkg.name}
-                                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? 'border-2 border-primary' : 'border'}`}
-                            >
-                                {pkg.featured && (
-                                    <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">Most popular</p>
-                                )}
-                                <h3 className="text-xl font-semibold">{pkg.name}</h3>
-                                <p className="mt-2 text-2xl font-bold">{pkg.price}</p>
-                                <p className="mt-2 text-sm text-muted-foreground">{pkg.description}</p>
-                                <ul className="mt-6 flex-1 space-y-2">
-                                    {pkg.features.map((f) => (
-                                        <li key={f} className="flex items-start gap-2 text-sm">
-                                            <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                                            <span className="text-muted-foreground">{f}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                                <div className="mt-8">
-                                    <ScheduleCallModal
-                                        trigger={
-                                            <Button
-                                                className="w-full"
-                                                variant={pkg.featured ? 'default' : 'outline'}
-                                            >
-                                                Get started
-                                            </Button>
-                                        }
-                                    />
-                                </div>
-                            </Card>
-                        ))}
-                    </div>
-                    <p className="mt-6 text-sm text-muted-foreground text-center">
-                        Optional ongoing support retainer available after any package.
-                    </p>
-                </div>
-            </section>
-
-            {/* FAQ */}
-            <section className="py-16 md:py-24 bg-muted/30">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">Common questions</h2>
-                    <div className="mx-auto mt-12 max-w-2xl">
-                        <Accordion type="single" collapsible className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0">
-                            {faqs.map((faq) => (
-                                <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
-                                    <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
-                                        {faq.question}
-                                    </AccordionTrigger>
-                                    <AccordionContent>
-                                        <p className="text-base">{faq.answer}</p>
-                                    </AccordionContent>
-                                </AccordionItem>
-                            ))}
-                        </Accordion>
-                    </div>
-                </div>
-            </section>
-
-            {/* CTA */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
-                        <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Ready to deploy?</h2>
-                        <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
-                            Most projects start with a 30-minute call — no commitment, just a conversation about what you're trying to automate and whether OpenClaw is the right approach. If it's not, we'll tell you.
-                        </p>
-                        <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button size="lg">
-                                        <span className="text-nowrap">Book a discovery call</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
-                            <Button asChild variant="outline" size="lg">
-                                <Link href={routes.contact}>Send us a message</Link>
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            </section>
+          </div>
         </div>
-    )
+      </section>
+
+      {/* Context */}
+      <section className="py-16 md:py-24 bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="max-w-3xl">
+            <h2 className="text-balance text-3xl font-semibold md:text-4xl">
+              We Build Agent Systems. This Is What We Do.
+            </h2>
+            <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
+              <p>
+                We didn't learn OpenClaw from a tutorial. We've built agent orchestration tools,
+                shipped them to production, and run our own multi-agent teams daily. When we deploy
+                OpenClaw for you, we're drawing on problems we've already solved on our own systems.
+              </p>
+              <p>
+                Juno, Lacy Shell, our own internal agent teams all run on these same patterns. We
+                know where the configuration gets tricky, which agent designs hold up under real
+                workloads, and how to keep the whole system from falling over on day two.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Benefits */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
+          <div className="mt-12 grid gap-8 md:grid-cols-2">
+            {benefits.map((benefit) => (
+              <div key={benefit.title} className="space-y-3">
+                <h3 className="text-lg font-semibold">{benefit.title}</h3>
+                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-12 rounded-2xl border bg-card p-8">
+            <h3 className="font-semibold">Every engagement includes:</h3>
+            <ul className="mt-4 space-y-2">
+              {[
+                "Architecture review and agent design",
+                "Full OpenClaw deployment (infrastructure, configuration, security, monitoring)",
+                "Custom agent development for your specific workflows",
+                "Training for your team on managing and extending the system",
+                "30 days of post-deployment support",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-sm">
+                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                  <span className="text-muted-foreground">{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="py-16 md:py-24 bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
+          <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
+            {steps.map((step) => (
+              <div key={step.number} className="flex gap-8 p-8">
+                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">
+                  {step.number}
+                </p>
+                <div>
+                  <h3 className="font-semibold text-lg">{step.title}</h3>
+                  <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
+          <p className="mt-4 text-muted-foreground">
+            All packages include architecture design, deployment, team training, and 30 days
+            post-launch support.
+          </p>
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
+            {packages.map((pkg) => (
+              <Card
+                key={pkg.name}
+                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? "border-2 border-primary" : "border"}`}
+              >
+                {pkg.featured && (
+                  <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">
+                    Most popular
+                  </p>
+                )}
+                <h3 className="text-xl font-semibold">{pkg.name}</h3>
+                <p className="mt-2 text-2xl font-bold">{pkg.price}</p>
+                <p className="mt-2 text-sm text-muted-foreground">{pkg.description}</p>
+                <ul className="mt-6 flex-1 space-y-2">
+                  {pkg.features.map((f) => (
+                    <li key={f} className="flex items-start gap-2 text-sm">
+                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                      <span className="text-muted-foreground">{f}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-8">
+                  <ScheduleCallModal
+                    trigger={
+                      <Button className="w-full" variant={pkg.featured ? "default" : "outline"}>
+                        Get started
+                      </Button>
+                    }
+                  />
+                </div>
+              </Card>
+            ))}
+          </div>
+          <p className="mt-6 text-sm text-muted-foreground text-center">
+            Optional ongoing support retainer available after any package.
+          </p>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="py-16 md:py-24 bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">
+            Common questions
+          </h2>
+          <div className="mx-auto mt-12 max-w-2xl">
+            <Accordion
+              type="single"
+              collapsible
+              className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0"
+            >
+              {faqs.map((faq) => (
+                <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
+                  <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
+                    {faq.question}
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <p className="text-base">{faq.answer}</p>
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
+            <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Ready to deploy?</h2>
+            <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+              Most projects start with a 30-minute call — no commitment, just a conversation about
+              what you're trying to automate and whether OpenClaw is the right approach. If it's
+              not, we'll tell you.
+            </p>
+            <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+              <ScheduleCallModal
+                trigger={
+                  <Button size="lg">
+                    <span className="text-nowrap">Book a discovery call</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
+              <Button asChild variant="outline" size="lg">
+                <Link href={routes.contact}>Send us a message</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/src/app/(app)/(main)/services/openclaw/page.tsx
+++ b/src/app/(app)/(main)/services/openclaw/page.tsx
@@ -1,0 +1,309 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
+import { ChevronRight, Check, ArrowLeft } from 'lucide-react'
+import { routes } from '@/config/routes'
+import { constructMetadata } from '@/config/metadata'
+
+export const metadata: Metadata = constructMetadata({
+    title: 'OpenClaw Setup & Deployment | Build And Serve',
+    description:
+        'Deploy AI agent orchestration with OpenClaw. We handle architecture, configuration, agent design, deployment, and training. $5K–$15K project-based.',
+})
+
+const steps = [
+    {
+        number: '01',
+        title: 'Discovery',
+        body: '60-minute call to understand your use case, your team, and what you want your agents doing. We\'ll tell you honestly whether OpenClaw is the right fit or if something simpler would work.',
+    },
+    {
+        number: '02',
+        title: 'Architecture & Design',
+        body: 'We design your agent topology — roles, communication patterns, data flows, security model. You review and sign off before we build anything.',
+    },
+    {
+        number: '03',
+        title: 'Build & Deploy',
+        body: 'We configure OpenClaw, build your custom agents, set up monitoring and alerting, and deploy to your infrastructure. Typical timeline: 2–4 weeks.',
+    },
+    {
+        number: '04',
+        title: 'Training & Handoff',
+        body: 'Your team gets hands-on training. We cover day-to-day management, adding new agents, troubleshooting, and extending the system. Plus 30 days of support after handoff.',
+    },
+]
+
+const benefits = [
+    {
+        title: 'Architecture That Holds Up',
+        body: 'Most agent deployments fail because the architecture was wrong from the start. We design your agent topology based on what actually works in production, not what looks good in a demo.',
+    },
+    {
+        title: 'Deployed in Weeks, Not Months',
+        body: 'A typical OpenClaw deployment takes 2–4 weeks from kickoff to production. We know the critical path and where teams waste time.',
+    },
+    {
+        title: 'You Own Everything',
+        body: 'No vendor lock-in, no proprietary wrapper. Your OpenClaw instance runs on your infrastructure, your accounts, your control.',
+    },
+    {
+        title: '30 Days of Post-Launch Support',
+        body: 'The first month after deployment is when the real questions come up. Bug fixes, configuration adjustments, agent tuning. We\'re there for it.',
+    },
+]
+
+const packages = [
+    {
+        name: 'Starter',
+        price: '$5,000–$7,500',
+        description: 'Single workflow, up to 3 agents, standard deployment',
+        features: ['Architecture design', 'Up to 3 custom agents', 'Standard deployment', 'Team training', '30 days post-launch support'],
+    },
+    {
+        name: 'Professional',
+        price: '$7,500–$12,000',
+        description: 'Multi-workflow, up to 8 agents, custom agent development',
+        features: ['Everything in Starter', 'Up to 8 custom agents', 'Multi-workflow orchestration', 'Custom agent development', 'Advanced monitoring'],
+        featured: true,
+    },
+    {
+        name: 'Enterprise',
+        price: '$12,000–$15,000+',
+        description: 'Complex orchestration, unlimited agents, dedicated support',
+        features: ['Everything in Professional', 'Unlimited agents', 'Complex orchestration', 'Dedicated support contact', 'Optional ongoing retainer'],
+    },
+]
+
+const faqs = [
+    {
+        id: 'faq-1',
+        question: 'What is OpenClaw?',
+        answer: 'OpenClaw is an open-source AI agent orchestration platform. It lets you deploy multiple AI agents that work together on tasks — coordinating, sharing context, and producing output that no single agent could handle alone. Think of it as the infrastructure layer for running AI teams.',
+    },
+    {
+        id: 'faq-2',
+        question: 'Do I need technical staff to manage OpenClaw after setup?',
+        answer: 'Someone on your team should be comfortable with basic system administration. We train your team during handoff, and the 30-day support period covers the initial learning curve. For ongoing management without internal technical staff, ask about our managed service.',
+    },
+    {
+        id: 'faq-3',
+        question: 'How long does a typical deployment take?',
+        answer: 'Two to four weeks from kickoff to production, depending on complexity. A single-workflow deployment with a few agents is on the faster end. Complex multi-agent systems with custom development take longer.',
+    },
+    {
+        id: 'faq-4',
+        question: 'Can I add more agents later?',
+        answer: "Yes. We design the architecture so adding agents later doesn't require rebuilding what's already there. You can add them yourself after training, or bring us back for more complex additions.",
+    },
+    {
+        id: 'faq-5',
+        question: 'How is this different from just using ChatGPT or Claude directly?',
+        answer: 'Direct AI usage is one person talking to one model. OpenClaw orchestration is multiple specialized agents coordinating on complex tasks — with monitoring, failure handling, and quality controls. It\'s the difference between asking someone a question and having a team work on a project.',
+    },
+]
+
+export default function OpenClawPage() {
+    return (
+        <div className="min-h-screen">
+            {/* Back nav */}
+            <div className="mx-auto max-w-5xl px-6 pt-8">
+                <Link
+                    href={routes.services}
+                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                    <ArrowLeft className="h-4 w-4" />
+                    All services
+                </Link>
+            </div>
+
+            {/* Hero */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <div className="max-w-2xl">
+                        <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">OpenClaw Setup & Deployment</p>
+                        <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
+                            Deploy AI Agent Teams That Actually Work
+                        </h1>
+                        <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
+                            We set up OpenClaw agent orchestration for your business — architecture, deployment, training. Your agents coordinating on real tasks in weeks, not months.
+                        </p>
+                        <p className="mt-4 text-sm text-muted-foreground">Starting at $5,000</p>
+                        <div className="mt-10">
+                            <ScheduleCallModal
+                                trigger={
+                                    <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
+                                        <span className="text-nowrap">Book a discovery call</span>
+                                        <ChevronRight className="ml-1" />
+                                    </Button>
+                                }
+                            />
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* Context */}
+            <section className="py-16 md:py-24 bg-muted/30">
+                <div className="mx-auto max-w-5xl px-6">
+                    <div className="max-w-3xl">
+                        <h2 className="text-balance text-3xl font-semibold md:text-4xl">We Build Agent Systems. This Is What We Do.</h2>
+                        <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
+                            <p>
+                                We didn't learn OpenClaw from a tutorial. We've built agent orchestration tools, shipped them to production, and run our own multi-agent teams daily. When we deploy OpenClaw for you, we're drawing on problems we've already solved on our own systems.
+                            </p>
+                            <p>
+                                Juno, Lacy Shell, our own internal agent teams all run on these same patterns. We know where the configuration gets tricky, which agent designs hold up under real workloads, and how to keep the whole system from falling over on day two.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* Benefits */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
+                    <div className="mt-12 grid gap-8 md:grid-cols-2">
+                        {benefits.map((benefit, i) => (
+                            <div key={i} className="space-y-3">
+                                <h3 className="text-lg font-semibold">{benefit.title}</h3>
+                                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="mt-12 rounded-2xl border bg-card p-8">
+                        <h3 className="font-semibold">Every engagement includes:</h3>
+                        <ul className="mt-4 space-y-2">
+                            {[
+                                'Architecture review and agent design',
+                                'Full OpenClaw deployment (infrastructure, configuration, security, monitoring)',
+                                'Custom agent development for your specific workflows',
+                                'Training for your team on managing and extending the system',
+                                '30 days of post-deployment support',
+                            ].map((item) => (
+                                <li key={item} className="flex items-start gap-3 text-sm">
+                                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                                    <span className="text-muted-foreground">{item}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            {/* How it works */}
+            <section className="py-16 md:py-24 bg-muted/30">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
+                    <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
+                        {steps.map((step) => (
+                            <div key={step.number} className="flex gap-8 p-8">
+                                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">{step.number}</p>
+                                <div>
+                                    <h3 className="font-semibold text-lg">{step.title}</h3>
+                                    <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* Pricing */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
+                    <p className="mt-4 text-muted-foreground">All packages include architecture design, deployment, team training, and 30 days post-launch support.</p>
+                    <div className="mt-12 grid gap-6 md:grid-cols-3">
+                        {packages.map((pkg) => (
+                            <Card
+                                key={pkg.name}
+                                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? 'border-2 border-primary' : 'border'}`}
+                            >
+                                {pkg.featured && (
+                                    <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">Most popular</p>
+                                )}
+                                <h3 className="text-xl font-semibold">{pkg.name}</h3>
+                                <p className="mt-2 text-2xl font-bold">{pkg.price}</p>
+                                <p className="mt-2 text-sm text-muted-foreground">{pkg.description}</p>
+                                <ul className="mt-6 flex-1 space-y-2">
+                                    {pkg.features.map((f) => (
+                                        <li key={f} className="flex items-start gap-2 text-sm">
+                                            <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                                            <span className="text-muted-foreground">{f}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                                <div className="mt-8">
+                                    <ScheduleCallModal
+                                        trigger={
+                                            <Button
+                                                className="w-full"
+                                                variant={pkg.featured ? 'default' : 'outline'}
+                                            >
+                                                Get started
+                                            </Button>
+                                        }
+                                    />
+                                </div>
+                            </Card>
+                        ))}
+                    </div>
+                    <p className="mt-6 text-sm text-muted-foreground text-center">
+                        Optional ongoing support retainer available after any package.
+                    </p>
+                </div>
+            </section>
+
+            {/* FAQ */}
+            <section className="py-16 md:py-24 bg-muted/30">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">Common questions</h2>
+                    <div className="mx-auto mt-12 max-w-2xl">
+                        <Accordion type="single" collapsible className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0">
+                            {faqs.map((faq) => (
+                                <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
+                                    <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
+                                        {faq.question}
+                                    </AccordionTrigger>
+                                    <AccordionContent>
+                                        <p className="text-base">{faq.answer}</p>
+                                    </AccordionContent>
+                                </AccordionItem>
+                            ))}
+                        </Accordion>
+                    </div>
+                </div>
+            </section>
+
+            {/* CTA */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
+                        <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Ready to deploy?</h2>
+                        <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                            Most projects start with a 30-minute call — no commitment, just a conversation about what you're trying to automate and whether OpenClaw is the right approach. If it's not, we'll tell you.
+                        </p>
+                        <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+                            <ScheduleCallModal
+                                trigger={
+                                    <Button size="lg">
+                                        <span className="text-nowrap">Book a discovery call</span>
+                                        <ChevronRight className="ml-1" />
+                                    </Button>
+                                }
+                            />
+                            <Button asChild variant="outline" size="lg">
+                                <Link href={routes.contact}>Send us a message</Link>
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    )
+}

--- a/src/app/(app)/(main)/services/page.tsx
+++ b/src/app/(app)/(main)/services/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
 import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, ArrowRight } from 'lucide-react'
 import { routes } from '@/config/routes'
 import { constructMetadata } from '@/config/metadata'
 import { ServicesFaq } from './_components/services-faq'
@@ -44,6 +45,45 @@ const services = [
         title: 'API development and integrations',
         body: "Whether you're building the API or connecting to someone else's, we do both well. Clean design, proper versioning, reliable performance under load. We've integrated enough third-party APIs to know which documentation misleads you and where the edge cases live.",
         goodFor: 'Third-party integrations, webhook systems, internal API layers, data pipelines',
+    },
+]
+
+const productizedServices = [
+    {
+        id: 'agent-team',
+        title: 'AI Agent Team — Managed Service',
+        badge: 'Managed',
+        body: 'We deploy, manage, and optimize AI agent teams that do real work for your business. Content creation, customer support triage, data analysis, research, reporting. We run it, you get the results. Includes ongoing management, weekly reporting on output volume and quality, and monthly strategy reviews.',
+        goodFor: 'Operations leaders at SMBs drowning in manual processes. Marketing teams that need steady content production without hiring.',
+        pricing: '$2K–$10K/month depending on scope',
+        href: routes.services,
+    },
+    {
+        id: 'shipkit',
+        title: 'ShipKit Launch Package',
+        badge: 'Fixed Price',
+        body: "ShipKit is our production-grade Next.js framework. The Launch Package means you don't buy a boilerplate and figure it out yourself. We build your app on ShipKit, customize it for your brand and use case, and hand you a deployed product in 1–2 weeks. Full source code handoff. No lock-in.",
+        goodFor: 'Solo founders who need to ship now. Early-stage startups validating with a real product instead of a mockup.',
+        pricing: '$2K–$5K standard · $7K–$10K Pro',
+        href: routes.services,
+    },
+    {
+        id: 'ai-audit',
+        title: 'AI Strategy & Audit',
+        badge: 'Fixed Price',
+        body: "We look at your operations, your team, your tools, and your bottlenecks. Then we tell you where AI saves real time and money. Not theoretical possibilities. Practical implementations you can act on in the next 90 days. You get a written report and 60-day action plan — not a 50-page deck that sits in a drawer.",
+        goodFor: 'Business owners who know AI matters but aren\'t sure where to start. Ops managers tasked with "figure out AI for us."',
+        pricing: '$1K–$3K · most land around $1,500–$2,000',
+        href: routes.services,
+    },
+    {
+        id: 'maintenance',
+        title: 'Website Maintenance & Support Retainer',
+        badge: 'Monthly',
+        body: 'You built something. Now someone needs to keep it running. Dependencies need updates. Security patches need applying. Performance needs monitoring. Features need tweaking. We handle all of it on a monthly retainer. Essentials starts at $500/mo. Growth adds performance optimization and feature hours. Scale includes dedicated support and AI-powered monitoring.',
+        goodFor: 'Any business running a Next.js or React app without a dedicated dev team.',
+        pricing: '$500–$3K/month · three tiers',
+        href: routes.services,
     },
 ]
 
@@ -115,6 +155,69 @@ export default function ServicesPage() {
                                     <span className="font-medium">Good fit for:</span>{' '}
                                     <span className="text-muted-foreground">{service.goodFor}</span>
                                 </p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* Dedicated Offerings */}
+            <section className="py-16 md:py-24 bg-muted/30">
+                <div className="mx-auto max-w-5xl px-6">
+                    <div className="max-w-2xl">
+                        <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">New offerings</p>
+                        <h2 className="mt-3 text-balance text-3xl font-semibold md:text-4xl">Productized services</h2>
+                        <p className="mt-4 text-muted-foreground leading-relaxed">
+                            Fixed scopes, clear pricing, defined timelines. Pick the one that matches where you are.
+                        </p>
+                    </div>
+
+                    {/* Dedicated landing pages */}
+                    <div className="mt-12 grid gap-6 md:grid-cols-2">
+                        <Link href="/services/openclaw" className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors">
+                            <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Dedicated offering</p>
+                            <h3 className="mt-2 text-xl font-semibold">OpenClaw Setup & Deployment</h3>
+                            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                                AI agent orchestration, deployed and running. We set up OpenClaw for businesses that want multi-agent systems without spending six months on the architecture.
+                            </p>
+                            <p className="mt-4 text-sm font-medium">$5K–$15K project-based</p>
+                            <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
+                                View full details <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                            </div>
+                        </Link>
+                        <Link href="/services/paperclip" className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors">
+                            <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Dedicated offering</p>
+                            <h3 className="mt-2 text-xl font-semibold">Paperclip AI Company Setup</h3>
+                            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                                Build your AI-powered company. Agent teams, workflows, governance. We built Paperclip — when we set you up, it's the people who made the platform doing the configuration.
+                            </p>
+                            <p className="mt-4 text-sm font-medium">$3K–$10K setup + optional management</p>
+                            <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
+                                View full details <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                            </div>
+                        </Link>
+                    </div>
+
+                    {/* Other productized services */}
+                    <div className="mt-8 divide-y rounded-2xl border bg-card">
+                        {productizedServices.map((service) => (
+                            <div key={service.id} className="p-8 first:pt-8 last:pb-8">
+                                <div className="flex flex-wrap items-start justify-between gap-4">
+                                    <div className="flex-1">
+                                        <div className="flex items-center gap-3">
+                                            <h3 className="text-lg font-semibold">{service.title}</h3>
+                                            <Badge variant="secondary" className="text-xs">{service.badge}</Badge>
+                                        </div>
+                                        <p className="mt-3 leading-relaxed text-muted-foreground text-sm">{service.body}</p>
+                                        <p className="mt-3 text-sm">
+                                            <span className="font-medium">Good fit for:</span>{' '}
+                                            <span className="text-muted-foreground">{service.goodFor}</span>
+                                        </p>
+                                    </div>
+                                    <div className="shrink-0 text-right">
+                                        <p className="text-sm font-medium text-muted-foreground">{service.pricing}</p>
+                                    </div>
+                                </div>
                             </div>
                         ))}
                     </div>

--- a/src/app/(app)/(main)/services/page.tsx
+++ b/src/app/(app)/(main)/services/page.tsx
@@ -1,324 +1,367 @@
-import type { Metadata } from 'next'
-import Link from 'next/link'
-import { Button, buttonVariants } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { Card } from '@/components/ui/card'
-import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
-import { ChevronRight, ArrowRight } from 'lucide-react'
-import { routes } from '@/config/routes'
-import { constructMetadata } from '@/config/metadata'
-import { ServicesFaq } from './_components/services-faq'
+import { ArrowRight, ChevronRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ScheduleCallModal } from "@/components/modals/schedule-call-modal";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { constructMetadata } from "@/config/metadata";
+import { routes } from "@/config/routes";
+import { ServicesFaq } from "./_components/services-faq";
 
 export const metadata: Metadata = constructMetadata({
-    title: 'Web Development Services | Build And Serve',
-    description:
-        'Next.js, React, AI integration, and full-stack development from a team with 20+ years of experience. Based in Charlotte. Working with startups and growing companies.',
-})
+  title: "Web Development Services | Build And Serve",
+  description:
+    "Next.js, React, AI integration, and full-stack development from a team with 20+ years of experience. Based in Charlotte. Working with startups and growing companies.",
+});
 
 const services = [
-    {
-        id: 'nextjs',
-        title: 'Next.js and React development',
-        body: "We've been building with React since early versions and Next.js since it became the obvious choice for production web apps. We know where projects go wrong, how to structure things for teams that grow, and how to ship something you won't have to rebuild in a year.",
-        goodFor: 'SaaS products, startup MVPs, customer portals, marketing sites that need to perform',
-    },
-    {
-        id: 'fullstack',
-        title: 'Full-stack web applications',
-        body: "Frontend to backend, database to deployment. We handle the whole stack so you're not coordinating five different contractors or explaining the same context to each one. That includes API design, database architecture, authentication, payments, background jobs — whatever your product needs to work.",
-        goodFor: 'Greenfield builds, platform redesigns, teams that need one person to own the whole thing',
-    },
-    {
-        id: 'ai',
-        title: 'AI integration and automation',
-        body: "We built our own AI desktop app (Juno) and AI terminal (Lacy Shell) in-house, so we understand AI integration from the inside. We know the difference between an integration that solves a real problem and one that just adds a line to the feature list. For client work, that means LLM-powered features that earn their place, agent workflows, internal automation that replaces manual processes, and RAG pipelines when search needs to get smarter.",
-        goodFor: 'Product AI features, back-office automation, LLM-powered tools, custom agent workflows',
-    },
-    {
-        id: 'performance',
-        title: 'Site speed and performance optimization',
-        body: "Slow sites lose money. Load time directly affects conversions. We audit what's actually slowing you down, then fix it: rendering strategy, image handling, caching, CDN setup, code splitting. We tell you what will actually move the metric before touching anything.",
-        goodFor: 'Sites with high traffic and dropping conversions, platforms that have scaled past their original architecture',
-    },
-    {
-        id: 'api',
-        title: 'API development and integrations',
-        body: "Whether you're building the API or connecting to someone else's, we do both well. Clean design, proper versioning, reliable performance under load. We've integrated enough third-party APIs to know which documentation misleads you and where the edge cases live.",
-        goodFor: 'Third-party integrations, webhook systems, internal API layers, data pipelines',
-    },
-]
+  {
+    id: "nextjs",
+    title: "Next.js and React development",
+    body: "We've been building with React since early versions and Next.js since it became the obvious choice for production web apps. We know where projects go wrong, how to structure things for teams that grow, and how to ship something you won't have to rebuild in a year.",
+    goodFor: "SaaS products, startup MVPs, customer portals, marketing sites that need to perform",
+  },
+  {
+    id: "fullstack",
+    title: "Full-stack web applications",
+    body: "Frontend to backend, database to deployment. We handle the whole stack so you're not coordinating five different contractors or explaining the same context to each one. That includes API design, database architecture, authentication, payments, background jobs — whatever your product needs to work.",
+    goodFor:
+      "Greenfield builds, platform redesigns, teams that need one person to own the whole thing",
+  },
+  {
+    id: "ai",
+    title: "AI integration and automation",
+    body: "We built our own AI desktop app (Juno) and AI terminal (Lacy Shell) in-house, so we understand AI integration from the inside. We know the difference between an integration that solves a real problem and one that just adds a line to the feature list. For client work, that means LLM-powered features that earn their place, agent workflows, internal automation that replaces manual processes, and RAG pipelines when search needs to get smarter.",
+    goodFor:
+      "Product AI features, back-office automation, LLM-powered tools, custom agent workflows",
+  },
+  {
+    id: "performance",
+    title: "Site speed and performance optimization",
+    body: "Slow sites lose money. Load time directly affects conversions. We audit what's actually slowing you down, then fix it: rendering strategy, image handling, caching, CDN setup, code splitting. We tell you what will actually move the metric before touching anything.",
+    goodFor:
+      "Sites with high traffic and dropping conversions, platforms that have scaled past their original architecture",
+  },
+  {
+    id: "api",
+    title: "API development and integrations",
+    body: "Whether you're building the API or connecting to someone else's, we do both well. Clean design, proper versioning, reliable performance under load. We've integrated enough third-party APIs to know which documentation misleads you and where the edge cases live.",
+    goodFor: "Third-party integrations, webhook systems, internal API layers, data pipelines",
+  },
+];
 
 const productizedServices = [
-    {
-        id: 'agent-team',
-        title: 'AI Agent Team — Managed Service',
-        badge: 'Managed',
-        body: 'We deploy, manage, and optimize AI agent teams that do real work for your business. Content creation, customer support triage, data analysis, research, reporting. We run it, you get the results. Includes ongoing management, weekly reporting on output volume and quality, and monthly strategy reviews.',
-        goodFor: 'Operations leaders at SMBs drowning in manual processes. Marketing teams that need steady content production without hiring.',
-        pricing: '$2K–$10K/month depending on scope',
-        href: routes.services,
-    },
-    {
-        id: 'shipkit',
-        title: 'ShipKit Launch Package',
-        badge: 'Fixed Price',
-        body: "ShipKit is our production-grade Next.js framework. The Launch Package means you don't buy a boilerplate and figure it out yourself. We build your app on ShipKit, customize it for your brand and use case, and hand you a deployed product in 1–2 weeks. Full source code handoff. No lock-in.",
-        goodFor: 'Solo founders who need to ship now. Early-stage startups validating with a real product instead of a mockup.',
-        pricing: '$2K–$5K standard · $7K–$10K Pro',
-        href: routes.services,
-    },
-    {
-        id: 'ai-audit',
-        title: 'AI Strategy & Audit',
-        badge: 'Fixed Price',
-        body: "We look at your operations, your team, your tools, and your bottlenecks. Then we tell you where AI saves real time and money. Not theoretical possibilities. Practical implementations you can act on in the next 90 days. You get a written report and 60-day action plan — not a 50-page deck that sits in a drawer.",
-        goodFor: 'Business owners who know AI matters but aren\'t sure where to start. Ops managers tasked with "figure out AI for us."',
-        pricing: '$1K–$3K · most land around $1,500–$2,000',
-        href: routes.services,
-    },
-    {
-        id: 'maintenance',
-        title: 'Website Maintenance & Support Retainer',
-        badge: 'Monthly',
-        body: 'You built something. Now someone needs to keep it running. Dependencies need updates. Security patches need applying. Performance needs monitoring. Features need tweaking. We handle all of it on a monthly retainer. Essentials starts at $500/mo. Growth adds performance optimization and feature hours. Scale includes dedicated support and AI-powered monitoring.',
-        goodFor: 'Any business running a Next.js or React app without a dedicated dev team.',
-        pricing: '$500–$3K/month · three tiers',
-        href: routes.services,
-    },
-]
+  {
+    id: "agent-team",
+    title: "AI Agent Team — Managed Service",
+    badge: "Managed",
+    body: "We deploy, manage, and optimize AI agent teams that do real work for your business. Content creation, customer support triage, data analysis, research, reporting. We run it, you get the results. Includes ongoing management, weekly reporting on output volume and quality, and monthly strategy reviews.",
+    goodFor:
+      "Operations leaders at SMBs drowning in manual processes. Marketing teams that need steady content production without hiring.",
+    pricing: "$2K–$10K/month depending on scope",
+    href: routes.services,
+  },
+  {
+    id: "shipkit",
+    title: "ShipKit Launch Package",
+    badge: "Fixed Price",
+    body: "ShipKit is our production-grade Next.js framework. The Launch Package means you don't buy a boilerplate and figure it out yourself. We build your app on ShipKit, customize it for your brand and use case, and hand you a deployed product in 1–2 weeks. Full source code handoff. No lock-in.",
+    goodFor:
+      "Solo founders who need to ship now. Early-stage startups validating with a real product instead of a mockup.",
+    pricing: "$2K–$5K standard · $7K–$10K Pro",
+    href: routes.services,
+  },
+  {
+    id: "ai-audit",
+    title: "AI Strategy & Audit",
+    badge: "Fixed Price",
+    body: "We look at your operations, your team, your tools, and your bottlenecks. Then we tell you where AI saves real time and money. Not theoretical possibilities. Practical implementations you can act on in the next 90 days. You get a written report and 60-day action plan — not a 50-page deck that sits in a drawer.",
+    goodFor:
+      'Business owners who know AI matters but aren\'t sure where to start. Ops managers tasked with "figure out AI for us."',
+    pricing: "$1K–$3K · most land around $1,500–$2,000",
+    href: routes.services,
+  },
+  {
+    id: "maintenance",
+    title: "Website Maintenance & Support Retainer",
+    badge: "Monthly",
+    body: "You built something. Now someone needs to keep it running. Dependencies need updates. Security patches need applying. Performance needs monitoring. Features need tweaking. We handle all of it on a monthly retainer. Essentials starts at $500/mo. Growth adds performance optimization and feature hours. Scale includes dedicated support and AI-powered monitoring.",
+    goodFor: "Any business running a Next.js or React app without a dedicated dev team.",
+    pricing: "$500–$3K/month · three tiers",
+    href: routes.services,
+  },
+];
 
 const caseStudies = [
-    {
-        id: 'shipkit',
-        title: 'ShipKit',
-        subtitle: 'Next.js application framework',
-        problem: 'Every new web app started with the same two weeks of setup: authentication, database connections, billing, email, multi-tenant architecture. All before writing a single line of actual product code.',
-        solution: 'Built ShipKit, a production-ready Next.js boilerplate with all of it included from the start. Auth, Stripe payments, a CMS layer, multi-tenant support, and a component library. Open source.',
-        outcome: 'Developers skip the setup phase entirely. Projects that used to take two weeks to get off the ground now start shipping product features from day one. Thousands of developers use the kit globally.',
-    },
-    {
-        id: 'juno',
-        title: 'Juno',
-        subtitle: 'AI desktop application',
-        problem: 'AI computer use needed a native interface that ran at desktop speed. Browser-based wrappers were sluggish and added overhead for a tool people would use constantly.',
-        solution: 'Built Juno from scratch in Rust with Tauri, a native Mac application that integrates directly with Claude Computer Use. The engineering focus was keeping the interface responsive while the AI was working in the background.',
-        outcome: 'A native AI desktop agent that handles computer use tasks without the performance hit of a browser wrapper. Shipped as a full product, not a prototype.',
-    },
-    {
-        id: 'lacy-shell',
-        title: 'Lacy Shell',
-        subtitle: 'AI terminal',
-        problem: 'AI-assisted development meant constant context switching: work in the terminal, copy to an AI chat window, paste back, repeat. The two tools never talked to each other.',
-        solution: "Built Lacy Shell as a ZSH/Bash plugin that routes commands between the shell and AI agents based on what you're doing. No new terminal to learn, it works inside your existing setup.",
-        outcome: 'AI assistance built into the terminal itself. Developers get context-aware AI help without leaving the command line. Available at lacy.sh.',
-    },
-]
+  {
+    id: "shipkit",
+    title: "ShipKit",
+    subtitle: "Next.js application framework",
+    problem:
+      "Every new web app started with the same two weeks of setup: authentication, database connections, billing, email, multi-tenant architecture. All before writing a single line of actual product code.",
+    solution:
+      "Built ShipKit, a production-ready Next.js boilerplate with all of it included from the start. Auth, Stripe payments, a CMS layer, multi-tenant support, and a component library. Open source.",
+    outcome:
+      "Developers skip the setup phase entirely. Projects that used to take two weeks to get off the ground now start shipping product features from day one. Thousands of developers use the kit globally.",
+  },
+  {
+    id: "juno",
+    title: "Juno",
+    subtitle: "AI desktop application",
+    problem:
+      "AI computer use needed a native interface that ran at desktop speed. Browser-based wrappers were sluggish and added overhead for a tool people would use constantly.",
+    solution:
+      "Built Juno from scratch in Rust with Tauri, a native Mac application that integrates directly with Claude Computer Use. The engineering focus was keeping the interface responsive while the AI was working in the background.",
+    outcome:
+      "A native AI desktop agent that handles computer use tasks without the performance hit of a browser wrapper. Shipped as a full product, not a prototype.",
+  },
+  {
+    id: "lacy-shell",
+    title: "Lacy Shell",
+    subtitle: "AI terminal",
+    problem:
+      "AI-assisted development meant constant context switching: work in the terminal, copy to an AI chat window, paste back, repeat. The two tools never talked to each other.",
+    solution:
+      "Built Lacy Shell as a ZSH/Bash plugin that routes commands between the shell and AI agents based on what you're doing. No new terminal to learn, it works inside your existing setup.",
+    outcome:
+      "AI assistance built into the terminal itself. Developers get context-aware AI help without leaving the command line. Available at lacy.sh.",
+  },
+];
 
 export default function ServicesPage() {
-    return (
-        <div className="min-h-screen">
-            {/* Hero */}
-            <section className="py-24 md:py-32">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="max-w-2xl">
-                        <h1 className="text-balance text-5xl font-semibold md:text-6xl lg:text-7xl">
-                            We handle the technical side. You focus on everything else.
-                        </h1>
-                        <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
-                            20 years of full-stack development. Built tools used by thousands of developers, integrated AI into
-                            production apps, and shipped fast for clients who needed to move.
-                        </p>
-                        <div className="mt-12">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
-                                        <span className="text-nowrap">Start a project</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            {/* Services */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">What we build</h2>
-                    <div className="mt-12 divide-y">
-                        {services.map((service) => (
-                            <div key={service.id} className="py-10 first:pt-0 last:pb-0">
-                                <h3 className="text-xl font-semibold">{service.title}</h3>
-                                <p className="mt-4 leading-relaxed text-muted-foreground">{service.body}</p>
-                                <p className="mt-4 text-sm">
-                                    <span className="font-medium">Good fit for:</span>{' '}
-                                    <span className="text-muted-foreground">{service.goodFor}</span>
-                                </p>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            {/* Dedicated Offerings */}
-            <section className="py-16 md:py-24 bg-muted/30">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="max-w-2xl">
-                        <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">New offerings</p>
-                        <h2 className="mt-3 text-balance text-3xl font-semibold md:text-4xl">Productized services</h2>
-                        <p className="mt-4 text-muted-foreground leading-relaxed">
-                            Fixed scopes, clear pricing, defined timelines. Pick the one that matches where you are.
-                        </p>
-                    </div>
-
-                    {/* Dedicated landing pages */}
-                    <div className="mt-12 grid gap-6 md:grid-cols-2">
-                        <Link href="/services/openclaw" className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors">
-                            <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Dedicated offering</p>
-                            <h3 className="mt-2 text-xl font-semibold">OpenClaw Setup & Deployment</h3>
-                            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                                AI agent orchestration, deployed and running. We set up OpenClaw for businesses that want multi-agent systems without spending six months on the architecture.
-                            </p>
-                            <p className="mt-4 text-sm font-medium">$5K–$15K project-based</p>
-                            <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
-                                View full details <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-                            </div>
-                        </Link>
-                        <Link href="/services/paperclip" className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors">
-                            <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">Dedicated offering</p>
-                            <h3 className="mt-2 text-xl font-semibold">Paperclip AI Company Setup</h3>
-                            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                                Build your AI-powered company. Agent teams, workflows, governance. We built Paperclip — when we set you up, it's the people who made the platform doing the configuration.
-                            </p>
-                            <p className="mt-4 text-sm font-medium">$3K–$10K setup + optional management</p>
-                            <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
-                                View full details <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-                            </div>
-                        </Link>
-                    </div>
-
-                    {/* Other productized services */}
-                    <div className="mt-8 divide-y rounded-2xl border bg-card">
-                        {productizedServices.map((service) => (
-                            <div key={service.id} className="p-8 first:pt-8 last:pb-8">
-                                <div className="flex flex-wrap items-start justify-between gap-4">
-                                    <div className="flex-1">
-                                        <div className="flex items-center gap-3">
-                                            <h3 className="text-lg font-semibold">{service.title}</h3>
-                                            <Badge variant="secondary" className="text-xs">{service.badge}</Badge>
-                                        </div>
-                                        <p className="mt-3 leading-relaxed text-muted-foreground text-sm">{service.body}</p>
-                                        <p className="mt-3 text-sm">
-                                            <span className="font-medium">Good fit for:</span>{' '}
-                                            <span className="text-muted-foreground">{service.goodFor}</span>
-                                        </p>
-                                    </div>
-                                    <div className="shrink-0 text-right">
-                                        <p className="text-sm font-medium text-muted-foreground">{service.pricing}</p>
-                                    </div>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            {/* Pricing */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <Card className="rounded-3xl border p-10 md:p-16">
-                        <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
-                        <div className="mt-8 max-w-2xl space-y-4 leading-relaxed text-muted-foreground">
-                            <p>
-                                Hourly rates run $100 to $200 depending on what the work requires. Complex AI work, architecture,
-                                and technical consulting sit at the higher end. Standard development and integrations are in the
-                                middle. Performance work and straightforward builds are at the lower end.
-                            </p>
-                            <p>
-                                Project-based pricing is available for well-defined scopes. We can talk through that on the discovery
-                                call.
-                            </p>
-                            <p>
-                                All projects start with a free 30-minute call. We'll tell you whether we're the right fit and roughly
-                                what it would cost before anyone commits to anything.
-                            </p>
-                        </div>
-                        <div className="mt-10">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
-                                        <span className="text-nowrap">Book a free call</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
-                        </div>
-                    </Card>
-                </div>
-            </section>
-
-            {/* Case Studies */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">What we've built</h2>
-                    <div className="mt-12 grid gap-8 md:grid-cols-3">
-                        {caseStudies.map((study) => (
-                            <Card key={study.id} className="flex flex-col rounded-2xl border p-8">
-                                <div>
-                                    <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                                        {study.subtitle}
-                                    </p>
-                                    <h3 className="mt-2 text-xl font-semibold">{study.title}</h3>
-                                </div>
-                                <div className="mt-6 space-y-4 text-sm leading-relaxed">
-                                    <div>
-                                        <p className="font-medium">Problem</p>
-                                        <p className="mt-1 text-muted-foreground">{study.problem}</p>
-                                    </div>
-                                    <div>
-                                        <p className="font-medium">Solution</p>
-                                        <p className="mt-1 text-muted-foreground">{study.solution}</p>
-                                    </div>
-                                    <div>
-                                        <p className="font-medium">Outcome</p>
-                                        <p className="mt-1 text-muted-foreground">{study.outcome}</p>
-                                    </div>
-                                </div>
-                            </Card>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            {/* CTA */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
-                        <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Have something to build?</h2>
-                        <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
-                            We keep the client list manageable. Most projects start with a 30-minute call, no commitment, just a
-                            conversation about what you're trying to build and whether we're the right people to help.
-                        </p>
-                        <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button size="lg">
-                                        <span className="text-nowrap">Book a discovery call</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
-                            <Button asChild variant="outline" size="lg">
-                                <Link href={routes.contact}>Send us a message</Link>
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            {/* FAQ */}
-            <ServicesFaq />
+  return (
+    <div className="min-h-screen">
+      {/* Hero */}
+      <section className="py-24 md:py-32">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="max-w-2xl">
+            <h1 className="text-balance text-5xl font-semibold md:text-6xl lg:text-7xl">
+              We handle the technical side. You focus on everything else.
+            </h1>
+            <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
+              20 years of full-stack development. Built tools used by thousands of developers,
+              integrated AI into production apps, and shipped fast for clients who needed to move.
+            </p>
+            <div className="mt-12">
+              <ScheduleCallModal
+                trigger={
+                  <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
+                    <span className="text-nowrap">Start a project</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
+            </div>
+          </div>
         </div>
-    )
+      </section>
+
+      {/* Services */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">What we build</h2>
+          <div className="mt-12 divide-y">
+            {services.map((service) => (
+              <div key={service.id} className="py-10 first:pt-0 last:pb-0">
+                <h3 className="text-xl font-semibold">{service.title}</h3>
+                <p className="mt-4 leading-relaxed text-muted-foreground">{service.body}</p>
+                <p className="mt-4 text-sm">
+                  <span className="font-medium">Good fit for:</span>{" "}
+                  <span className="text-muted-foreground">{service.goodFor}</span>
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Dedicated Offerings */}
+      <section className="py-16 md:py-24 bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
+              New offerings
+            </p>
+            <h2 className="mt-3 text-balance text-3xl font-semibold md:text-4xl">
+              Productized services
+            </h2>
+            <p className="mt-4 text-muted-foreground leading-relaxed">
+              Fixed scopes, clear pricing, defined timelines. Pick the one that matches where you
+              are.
+            </p>
+          </div>
+
+          {/* Dedicated landing pages */}
+          <div className="mt-12 grid gap-6 md:grid-cols-2">
+            <Link
+              href="/services/openclaw"
+              className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors"
+            >
+              <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                Dedicated offering
+              </p>
+              <h3 className="mt-2 text-xl font-semibold">OpenClaw Setup & Deployment</h3>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                AI agent orchestration, deployed and running. We set up OpenClaw for businesses that
+                want multi-agent systems without spending six months on the architecture.
+              </p>
+              <p className="mt-4 text-sm font-medium">$5K–$15K project-based</p>
+              <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
+                View full details{" "}
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+              </div>
+            </Link>
+            <Link
+              href="/services/paperclip"
+              className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors"
+            >
+              <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                Dedicated offering
+              </p>
+              <h3 className="mt-2 text-xl font-semibold">Paperclip AI Company Setup</h3>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                Build your AI-powered company. Agent teams, workflows, governance. We built
+                Paperclip — when we set you up, it's the people who made the platform doing the
+                configuration.
+              </p>
+              <p className="mt-4 text-sm font-medium">$3K–$10K setup + optional management</p>
+              <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
+                View full details{" "}
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+              </div>
+            </Link>
+          </div>
+
+          {/* Other productized services */}
+          <div className="mt-8 divide-y rounded-2xl border bg-card">
+            {productizedServices.map((service) => (
+              <div key={service.id} className="p-8 first:pt-8 last:pb-8">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3">
+                      <h3 className="text-lg font-semibold">{service.title}</h3>
+                      <Badge variant="secondary" className="text-xs">
+                        {service.badge}
+                      </Badge>
+                    </div>
+                    <p className="mt-3 leading-relaxed text-muted-foreground text-sm">
+                      {service.body}
+                    </p>
+                    <p className="mt-3 text-sm">
+                      <span className="font-medium">Good fit for:</span>{" "}
+                      <span className="text-muted-foreground">{service.goodFor}</span>
+                    </p>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <p className="text-sm font-medium text-muted-foreground">{service.pricing}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <Card className="rounded-3xl border p-10 md:p-16">
+            <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
+            <div className="mt-8 max-w-2xl space-y-4 leading-relaxed text-muted-foreground">
+              <p>
+                Hourly rates run $100 to $200 depending on what the work requires. Complex AI work,
+                architecture, and technical consulting sit at the higher end. Standard development
+                and integrations are in the middle. Performance work and straightforward builds are
+                at the lower end.
+              </p>
+              <p>
+                Project-based pricing is available for well-defined scopes. We can talk through that
+                on the discovery call.
+              </p>
+              <p>
+                All projects start with a free 30-minute call. We'll tell you whether we're the
+                right fit and roughly what it would cost before anyone commits to anything.
+              </p>
+            </div>
+            <div className="mt-10">
+              <ScheduleCallModal
+                trigger={
+                  <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
+                    <span className="text-nowrap">Book a free call</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
+            </div>
+          </Card>
+        </div>
+      </section>
+
+      {/* Case Studies */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">What we've built</h2>
+          <div className="mt-12 grid gap-8 md:grid-cols-3">
+            {caseStudies.map((study) => (
+              <Card key={study.id} className="flex flex-col rounded-2xl border p-8">
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                    {study.subtitle}
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold">{study.title}</h3>
+                </div>
+                <div className="mt-6 space-y-4 text-sm leading-relaxed">
+                  <div>
+                    <p className="font-medium">Problem</p>
+                    <p className="mt-1 text-muted-foreground">{study.problem}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Solution</p>
+                    <p className="mt-1 text-muted-foreground">{study.solution}</p>
+                  </div>
+                  <div>
+                    <p className="font-medium">Outcome</p>
+                    <p className="mt-1 text-muted-foreground">{study.outcome}</p>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
+            <h2 className="text-balance text-4xl font-semibold lg:text-5xl">
+              Have something to build?
+            </h2>
+            <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+              We keep the client list manageable. Most projects start with a 30-minute call, no
+              commitment, just a conversation about what you're trying to build and whether we're
+              the right people to help.
+            </p>
+            <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+              <ScheduleCallModal
+                trigger={
+                  <Button size="lg">
+                    <span className="text-nowrap">Book a discovery call</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
+              <Button asChild variant="outline" size="lg">
+                <Link href={routes.contact}>Send us a message</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <ServicesFaq />
+    </div>
+  );
 }

--- a/src/app/(app)/(main)/services/paperclip/page.tsx
+++ b/src/app/(app)/(main)/services/paperclip/page.tsx
@@ -1,316 +1,374 @@
-import type { Metadata } from 'next'
-import Link from 'next/link'
-import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
-import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
-import { ChevronRight, Check, ArrowLeft } from 'lucide-react'
-import { routes } from '@/config/routes'
-import { constructMetadata } from '@/config/metadata'
+import { ArrowLeft, Check, ChevronRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ScheduleCallModal } from "@/components/modals/schedule-call-modal";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { constructMetadata } from "@/config/metadata";
+import { routes } from "@/config/routes";
 
 export const metadata: Metadata = constructMetadata({
-    title: 'Paperclip AI Company Setup | Build And Serve',
-    description:
-        'Stand up an AI-powered company with agent teams via Paperclip. Company design, agent hiring, workflow setup, and governance. $3K–$10K setup + optional management.',
-})
+  title: "Paperclip AI Company Setup | Build And Serve",
+  description:
+    "Stand up an AI-powered company with agent teams via Paperclip. Company design, agent hiring, workflow setup, and governance. $3K–$10K setup + optional management.",
+});
 
 const steps = [
-    {
-        number: '01',
-        title: 'Company Design',
-        body: 'We map your operations to an agent team structure. Which roles do you need? What workflows should agents handle? Where does human oversight matter most? We design the org chart for your AI company.',
-    },
-    {
-        number: '02',
-        title: 'Agent Setup',
-        body: 'We hire and configure your agents — each one specialized for its role, trained on your context, and tested against real tasks before going live.',
-    },
-    {
-        number: '03',
-        title: 'Workflow Configuration',
-        body: 'Task routing, approval chains, escalation paths, budget controls, reporting dashboards. We wire up the operational backbone so your AI company runs smoothly from day one.',
-    },
-    {
-        number: '04',
-        title: 'Launch & Support',
-        body: 'Your AI company goes live. We stick around for 60 days to help you manage and adjust. By the end, you\'re running it on your own — or you can add our managed service if you\'d rather not.',
-    },
-]
+  {
+    number: "01",
+    title: "Company Design",
+    body: "We map your operations to an agent team structure. Which roles do you need? What workflows should agents handle? Where does human oversight matter most? We design the org chart for your AI company.",
+  },
+  {
+    number: "02",
+    title: "Agent Setup",
+    body: "We hire and configure your agents — each one specialized for its role, trained on your context, and tested against real tasks before going live.",
+  },
+  {
+    number: "03",
+    title: "Workflow Configuration",
+    body: "Task routing, approval chains, escalation paths, budget controls, reporting dashboards. We wire up the operational backbone so your AI company runs smoothly from day one.",
+  },
+  {
+    number: "04",
+    title: "Launch & Support",
+    body: "Your AI company goes live. We stick around for 60 days to help you manage and adjust. By the end, you're running it on your own — or you can add our managed service if you'd rather not.",
+  },
+];
 
 const benefits = [
-    {
-        title: 'A Real Operating System, Not Another Tool',
-        body: "Paperclip isn't a chatbot builder or a workflow automation platform. It's a management layer for AI agent teams — with roles, task assignment, approval chains, budgets, escalation, and oversight.",
-    },
-    {
-        title: 'Agents That Do Actual Work',
-        body: 'Your agents write content, handle support tickets, analyze data, manage projects, and coordinate with each other on complex tasks. We configure each agent for your specific workflows.',
-    },
-    {
-        title: 'You Stay in Control',
-        body: 'Every action an agent takes is visible, auditable, and governed by rules you set. Budget limits, approval gates, escalation paths — you decide how much autonomy your agents get.',
-    },
-    {
-        title: '60 Days of Hands-On Support',
-        body: "The first two months are when you figure out how to actually run this thing. We're there for all of it. Adjusting agents, tuning workflows, answering the questions you didn't know you'd have.",
-    },
-]
+  {
+    title: "A Real Operating System, Not Another Tool",
+    body: "Paperclip isn't a chatbot builder or a workflow automation platform. It's a management layer for AI agent teams — with roles, task assignment, approval chains, budgets, escalation, and oversight.",
+  },
+  {
+    title: "Agents That Do Actual Work",
+    body: "Your agents write content, handle support tickets, analyze data, manage projects, and coordinate with each other on complex tasks. We configure each agent for your specific workflows.",
+  },
+  {
+    title: "You Stay in Control",
+    body: "Every action an agent takes is visible, auditable, and governed by rules you set. Budget limits, approval gates, escalation paths — you decide how much autonomy your agents get.",
+  },
+  {
+    title: "60 Days of Hands-On Support",
+    body: "The first two months are when you figure out how to actually run this thing. We're there for all of it. Adjusting agents, tuning workflows, answering the questions you didn't know you'd have.",
+  },
+];
 
 const packages = [
-    {
-        name: 'Foundation',
-        price: '$5,000–$8,000',
-        priceNote: 'setup',
-        description: 'Up to 3 agents, core workflows, basic governance',
-        features: ['Company design session', 'Up to 3 configured agents', 'Core workflow setup', 'Basic governance controls', 'Team training', '60 days post-launch support'],
-    },
-    {
-        name: 'Growth',
-        price: '$8,000–$12,000',
-        priceNote: 'setup',
-        description: 'Up to 8 agents, advanced workflows, full governance suite',
-        features: ['Everything in Foundation', 'Up to 8 configured agents', 'Advanced workflows', 'Full governance suite', 'Approval chains & budget controls', 'Reporting dashboards'],
-        featured: true,
-    },
-    {
-        name: 'Scale',
-        price: '$12,000–$15,000+',
-        priceNote: 'setup',
-        description: 'Unlimited agents, complex operations, custom integrations',
-        features: ['Everything in Growth', 'Unlimited agents', 'Complex multi-workflow ops', 'Custom integrations', 'Priority support', 'Optional ongoing management'],
-    },
-]
+  {
+    name: "Foundation",
+    price: "$5,000–$8,000",
+    priceNote: "setup",
+    description: "Up to 3 agents, core workflows, basic governance",
+    features: [
+      "Company design session",
+      "Up to 3 configured agents",
+      "Core workflow setup",
+      "Basic governance controls",
+      "Team training",
+      "60 days post-launch support",
+    ],
+  },
+  {
+    name: "Growth",
+    price: "$8,000–$12,000",
+    priceNote: "setup",
+    description: "Up to 8 agents, advanced workflows, full governance suite",
+    features: [
+      "Everything in Foundation",
+      "Up to 8 configured agents",
+      "Advanced workflows",
+      "Full governance suite",
+      "Approval chains & budget controls",
+      "Reporting dashboards",
+    ],
+    featured: true,
+  },
+  {
+    name: "Scale",
+    price: "$12,000–$15,000+",
+    priceNote: "setup",
+    description: "Unlimited agents, complex operations, custom integrations",
+    features: [
+      "Everything in Growth",
+      "Unlimited agents",
+      "Complex multi-workflow ops",
+      "Custom integrations",
+      "Priority support",
+      "Optional ongoing management",
+    ],
+  },
+];
 
 const faqs = [
-    {
-        id: 'faq-1',
-        question: 'What exactly is an "AI company"?',
-        answer: "It's a structured team of AI agents that operates like a real company — with defined roles, task assignments, approval workflows, budgets, and oversight. Instead of using AI as a tool, you're deploying AI as a workforce with governance.",
-    },
-    {
-        id: 'faq-2',
-        question: 'What kinds of tasks can AI agents handle?',
-        answer: 'Content creation, customer support triage, data analysis, research, project coordination, code review, reporting, email drafting, social media management. Most knowledge work that follows repeatable patterns. We help you identify the highest-impact workflows during design.',
-    },
-    {
-        id: 'faq-3',
-        question: 'How much does it cost to run the agents after setup?',
-        answer: "Agent operating costs depend on usage volume and which AI models your agents use. Typical monthly costs range from a few hundred dollars for light usage to a few thousand for heavy operations. We'll give you cost projections during the design phase so there are no surprises.",
-    },
-    {
-        id: 'faq-4',
-        question: 'Do I need to know how to code?',
-        answer: "No. Paperclip is designed for non-technical operators. The management dashboard is visual, and we train you on everything during setup. If you can manage a team of people, you can manage a team of agents.",
-    },
-    {
-        id: 'faq-5',
-        question: 'What happens if an agent makes a mistake?',
-        answer: 'Governance controls catch most issues before they reach anyone. Approval gates require human sign-off on sensitive actions. Budget limits prevent runaway spending. Every action is logged, so you can see exactly what happened and adjust.',
-    },
-]
+  {
+    id: "faq-1",
+    question: 'What exactly is an "AI company"?',
+    answer:
+      "It's a structured team of AI agents that operates like a real company — with defined roles, task assignments, approval workflows, budgets, and oversight. Instead of using AI as a tool, you're deploying AI as a workforce with governance.",
+  },
+  {
+    id: "faq-2",
+    question: "What kinds of tasks can AI agents handle?",
+    answer:
+      "Content creation, customer support triage, data analysis, research, project coordination, code review, reporting, email drafting, social media management. Most knowledge work that follows repeatable patterns. We help you identify the highest-impact workflows during design.",
+  },
+  {
+    id: "faq-3",
+    question: "How much does it cost to run the agents after setup?",
+    answer:
+      "Agent operating costs depend on usage volume and which AI models your agents use. Typical monthly costs range from a few hundred dollars for light usage to a few thousand for heavy operations. We'll give you cost projections during the design phase so there are no surprises.",
+  },
+  {
+    id: "faq-4",
+    question: "Do I need to know how to code?",
+    answer:
+      "No. Paperclip is designed for non-technical operators. The management dashboard is visual, and we train you on everything during setup. If you can manage a team of people, you can manage a team of agents.",
+  },
+  {
+    id: "faq-5",
+    question: "What happens if an agent makes a mistake?",
+    answer:
+      "Governance controls catch most issues before they reach anyone. Approval gates require human sign-off on sensitive actions. Budget limits prevent runaway spending. Every action is logged, so you can see exactly what happened and adjust.",
+  },
+];
 
 export default function PaperclipPage() {
-    return (
-        <div className="min-h-screen">
-            {/* Back nav */}
-            <div className="mx-auto max-w-5xl px-6 pt-8">
-                <Link
-                    href={routes.services}
-                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                >
-                    <ArrowLeft className="h-4 w-4" />
-                    All services
-                </Link>
+  return (
+    <div className="min-h-screen">
+      {/* Back nav */}
+      <div className="mx-auto max-w-5xl px-6 pt-8">
+        <Link
+          href={routes.services}
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          All services
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
+              Paperclip AI Company Setup
+            </p>
+            <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
+              Build Your AI-Powered Company
+            </h1>
+            <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
+              We set up Paperclip for your business — agent teams, workflows, governance. A
+              structured AI workforce handling real tasks, managed by you.
+            </p>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Setup starts at $5,000 · Optional monthly management $1K–$3K/mo
+            </p>
+            <div className="mt-10">
+              <ScheduleCallModal
+                trigger={
+                  <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
+                    <span className="text-nowrap">Book a discovery call</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
             </div>
-
-            {/* Hero */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="max-w-2xl">
-                        <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">Paperclip AI Company Setup</p>
-                        <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
-                            Build Your AI-Powered Company
-                        </h1>
-                        <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
-                            We set up Paperclip for your business — agent teams, workflows, governance. A structured AI workforce handling real tasks, managed by you.
-                        </p>
-                        <p className="mt-4 text-sm text-muted-foreground">Setup starts at $5,000 · Optional monthly management $1K–$3K/mo</p>
-                        <div className="mt-10">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
-                                        <span className="text-nowrap">Book a discovery call</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            {/* Context */}
-            <section className="py-16 md:py-24 bg-muted/30">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="max-w-3xl">
-                        <h2 className="text-balance text-3xl font-semibold md:text-4xl">Built by the People Who Built Paperclip</h2>
-                        <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
-                            <p>
-                                Paperclip is our platform. When we set up your AI company, you're getting the team that designed the system and runs their own operations on it every day. That's the practical difference between a setup that works and one that needs constant fixing.
-                            </p>
-                            <p>
-                                We're not writing reports about what you could do with AI someday. We're standing up a working system with real agents doing real tasks by the time we hand it over.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            {/* Benefits */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
-                    <div className="mt-12 grid gap-8 md:grid-cols-2">
-                        {benefits.map((benefit, i) => (
-                            <div key={i} className="space-y-3">
-                                <h3 className="text-lg font-semibold">{benefit.title}</h3>
-                                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
-                            </div>
-                        ))}
-                    </div>
-                    <div className="mt-12 rounded-2xl border bg-card p-8">
-                        <h3 className="font-semibold">Every engagement includes:</h3>
-                        <ul className="mt-4 space-y-2">
-                            {[
-                                'Company design: we map your operations to an agent team structure that actually makes sense',
-                                'Agent hiring and configuration for your specific workflows',
-                                'Workflow setup: task routing, approval chains, escalation paths, budget controls',
-                                'Governance configuration: permissions, spending limits, oversight dashboards',
-                                'Team training on managing your AI company',
-                                '60 days of management support to get you past the learning curve',
-                            ].map((item) => (
-                                <li key={item} className="flex items-start gap-3 text-sm">
-                                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                                    <span className="text-muted-foreground">{item}</span>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                </div>
-            </section>
-
-            {/* How it works */}
-            <section className="py-16 md:py-24 bg-muted/30">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
-                    <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
-                        {steps.map((step) => (
-                            <div key={step.number} className="flex gap-8 p-8">
-                                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">{step.number}</p>
-                                <div>
-                                    <h3 className="font-semibold text-lg">{step.title}</h3>
-                                    <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            </section>
-
-            {/* Pricing */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
-                    <p className="mt-4 text-muted-foreground">All packages include company design, agent setup, workflow configuration, team training, and 60 days post-launch support.</p>
-                    <div className="mt-12 grid gap-6 md:grid-cols-3">
-                        {packages.map((pkg) => (
-                            <Card
-                                key={pkg.name}
-                                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? 'border-2 border-primary' : 'border'}`}
-                            >
-                                {pkg.featured && (
-                                    <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">Most popular</p>
-                                )}
-                                <h3 className="text-xl font-semibold">{pkg.name}</h3>
-                                <div className="mt-2">
-                                    <span className="text-2xl font-bold">{pkg.price}</span>
-                                    {pkg.priceNote && <span className="ml-1 text-sm text-muted-foreground">{pkg.priceNote}</span>}
-                                </div>
-                                <p className="mt-2 text-sm text-muted-foreground">{pkg.description}</p>
-                                <ul className="mt-6 flex-1 space-y-2">
-                                    {pkg.features.map((f) => (
-                                        <li key={f} className="flex items-start gap-2 text-sm">
-                                            <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
-                                            <span className="text-muted-foreground">{f}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                                <div className="mt-8">
-                                    <ScheduleCallModal
-                                        trigger={
-                                            <Button
-                                                className="w-full"
-                                                variant={pkg.featured ? 'default' : 'outline'}
-                                            >
-                                                Get started
-                                            </Button>
-                                        }
-                                    />
-                                </div>
-                            </Card>
-                        ))}
-                    </div>
-                    <p className="mt-6 text-sm text-muted-foreground text-center">
-                        Optional monthly management: $1,000–$3,000/mo — we handle ongoing optimization, agent additions, and system maintenance.
-                    </p>
-                </div>
-            </section>
-
-            {/* FAQ */}
-            <section className="py-16 md:py-24 bg-muted/30">
-                <div className="mx-auto max-w-5xl px-6">
-                    <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">Common questions</h2>
-                    <div className="mx-auto mt-12 max-w-2xl">
-                        <Accordion type="single" collapsible className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0">
-                            {faqs.map((faq) => (
-                                <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
-                                    <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
-                                        {faq.question}
-                                    </AccordionTrigger>
-                                    <AccordionContent>
-                                        <p className="text-base">{faq.answer}</p>
-                                    </AccordionContent>
-                                </AccordionItem>
-                            ))}
-                        </Accordion>
-                    </div>
-                </div>
-            </section>
-
-            {/* CTA */}
-            <section className="py-16 md:py-24">
-                <div className="mx-auto max-w-5xl px-6">
-                    <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
-                        <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Let's talk about your AI company.</h2>
-                        <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
-                            30-minute call, no commitment. We'll discuss what your operations look like, which agent roles make sense, and what the setup would involve. If Paperclip isn't the right fit, we'll say so.
-                        </p>
-                        <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
-                            <ScheduleCallModal
-                                trigger={
-                                    <Button size="lg">
-                                        <span className="text-nowrap">Book a discovery call</span>
-                                        <ChevronRight className="ml-1" />
-                                    </Button>
-                                }
-                            />
-                            <Button asChild variant="outline" size="lg">
-                                <Link href={routes.contact}>Send us a message</Link>
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            </section>
+          </div>
         </div>
-    )
+      </section>
+
+      {/* Context */}
+      <section className="py-16 md:py-24 bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="max-w-3xl">
+            <h2 className="text-balance text-3xl font-semibold md:text-4xl">
+              Built by the People Who Built Paperclip
+            </h2>
+            <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
+              <p>
+                Paperclip is our platform. When we set up your AI company, you're getting the team
+                that designed the system and runs their own operations on it every day. That's the
+                practical difference between a setup that works and one that needs constant fixing.
+              </p>
+              <p>
+                We're not writing reports about what you could do with AI someday. We're standing up
+                a working system with real agents doing real tasks by the time we hand it over.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Benefits */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
+          <div className="mt-12 grid gap-8 md:grid-cols-2">
+            {benefits.map((benefit) => (
+              <div key={benefit.title} className="space-y-3">
+                <h3 className="text-lg font-semibold">{benefit.title}</h3>
+                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-12 rounded-2xl border bg-card p-8">
+            <h3 className="font-semibold">Every engagement includes:</h3>
+            <ul className="mt-4 space-y-2">
+              {[
+                "Company design: we map your operations to an agent team structure that actually makes sense",
+                "Agent hiring and configuration for your specific workflows",
+                "Workflow setup: task routing, approval chains, escalation paths, budget controls",
+                "Governance configuration: permissions, spending limits, oversight dashboards",
+                "Team training on managing your AI company",
+                "60 days of management support to get you past the learning curve",
+              ].map((item) => (
+                <li key={item} className="flex items-start gap-3 text-sm">
+                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                  <span className="text-muted-foreground">{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section className="py-16 md:py-24 bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
+          <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
+            {steps.map((step) => (
+              <div key={step.number} className="flex gap-8 p-8">
+                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">
+                  {step.number}
+                </p>
+                <div>
+                  <h3 className="font-semibold text-lg">{step.title}</h3>
+                  <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
+          <p className="mt-4 text-muted-foreground">
+            All packages include company design, agent setup, workflow configuration, team training,
+            and 60 days post-launch support.
+          </p>
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
+            {packages.map((pkg) => (
+              <Card
+                key={pkg.name}
+                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? "border-2 border-primary" : "border"}`}
+              >
+                {pkg.featured && (
+                  <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">
+                    Most popular
+                  </p>
+                )}
+                <h3 className="text-xl font-semibold">{pkg.name}</h3>
+                <div className="mt-2">
+                  <span className="text-2xl font-bold">{pkg.price}</span>
+                  {pkg.priceNote && (
+                    <span className="ml-1 text-sm text-muted-foreground">{pkg.priceNote}</span>
+                  )}
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">{pkg.description}</p>
+                <ul className="mt-6 flex-1 space-y-2">
+                  {pkg.features.map((f) => (
+                    <li key={f} className="flex items-start gap-2 text-sm">
+                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                      <span className="text-muted-foreground">{f}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-8">
+                  <ScheduleCallModal
+                    trigger={
+                      <Button className="w-full" variant={pkg.featured ? "default" : "outline"}>
+                        Get started
+                      </Button>
+                    }
+                  />
+                </div>
+              </Card>
+            ))}
+          </div>
+          <p className="mt-6 text-sm text-muted-foreground text-center">
+            Optional monthly management: $1,000–$3,000/mo — we handle ongoing optimization, agent
+            additions, and system maintenance.
+          </p>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="py-16 md:py-24 bg-muted/30">
+        <div className="mx-auto max-w-5xl px-6">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">
+            Common questions
+          </h2>
+          <div className="mx-auto mt-12 max-w-2xl">
+            <Accordion
+              type="single"
+              collapsible
+              className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0"
+            >
+              {faqs.map((faq) => (
+                <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
+                  <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
+                    {faq.question}
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <p className="text-base">{faq.answer}</p>
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
+            <h2 className="text-balance text-4xl font-semibold lg:text-5xl">
+              Let's talk about your AI company.
+            </h2>
+            <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+              30-minute call, no commitment. We'll discuss what your operations look like, which
+              agent roles make sense, and what the setup would involve. If Paperclip isn't the right
+              fit, we'll say so.
+            </p>
+            <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+              <ScheduleCallModal
+                trigger={
+                  <Button size="lg">
+                    <span className="text-nowrap">Book a discovery call</span>
+                    <ChevronRight className="ml-1" />
+                  </Button>
+                }
+              />
+              <Button asChild variant="outline" size="lg">
+                <Link href={routes.contact}>Send us a message</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/src/app/(app)/(main)/services/paperclip/page.tsx
+++ b/src/app/(app)/(main)/services/paperclip/page.tsx
@@ -1,0 +1,316 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { ScheduleCallModal } from '@/components/modals/schedule-call-modal'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
+import { ChevronRight, Check, ArrowLeft } from 'lucide-react'
+import { routes } from '@/config/routes'
+import { constructMetadata } from '@/config/metadata'
+
+export const metadata: Metadata = constructMetadata({
+    title: 'Paperclip AI Company Setup | Build And Serve',
+    description:
+        'Stand up an AI-powered company with agent teams via Paperclip. Company design, agent hiring, workflow setup, and governance. $3K–$10K setup + optional management.',
+})
+
+const steps = [
+    {
+        number: '01',
+        title: 'Company Design',
+        body: 'We map your operations to an agent team structure. Which roles do you need? What workflows should agents handle? Where does human oversight matter most? We design the org chart for your AI company.',
+    },
+    {
+        number: '02',
+        title: 'Agent Setup',
+        body: 'We hire and configure your agents — each one specialized for its role, trained on your context, and tested against real tasks before going live.',
+    },
+    {
+        number: '03',
+        title: 'Workflow Configuration',
+        body: 'Task routing, approval chains, escalation paths, budget controls, reporting dashboards. We wire up the operational backbone so your AI company runs smoothly from day one.',
+    },
+    {
+        number: '04',
+        title: 'Launch & Support',
+        body: 'Your AI company goes live. We stick around for 60 days to help you manage and adjust. By the end, you\'re running it on your own — or you can add our managed service if you\'d rather not.',
+    },
+]
+
+const benefits = [
+    {
+        title: 'A Real Operating System, Not Another Tool',
+        body: "Paperclip isn't a chatbot builder or a workflow automation platform. It's a management layer for AI agent teams — with roles, task assignment, approval chains, budgets, escalation, and oversight.",
+    },
+    {
+        title: 'Agents That Do Actual Work',
+        body: 'Your agents write content, handle support tickets, analyze data, manage projects, and coordinate with each other on complex tasks. We configure each agent for your specific workflows.',
+    },
+    {
+        title: 'You Stay in Control',
+        body: 'Every action an agent takes is visible, auditable, and governed by rules you set. Budget limits, approval gates, escalation paths — you decide how much autonomy your agents get.',
+    },
+    {
+        title: '60 Days of Hands-On Support',
+        body: "The first two months are when you figure out how to actually run this thing. We're there for all of it. Adjusting agents, tuning workflows, answering the questions you didn't know you'd have.",
+    },
+]
+
+const packages = [
+    {
+        name: 'Foundation',
+        price: '$5,000–$8,000',
+        priceNote: 'setup',
+        description: 'Up to 3 agents, core workflows, basic governance',
+        features: ['Company design session', 'Up to 3 configured agents', 'Core workflow setup', 'Basic governance controls', 'Team training', '60 days post-launch support'],
+    },
+    {
+        name: 'Growth',
+        price: '$8,000–$12,000',
+        priceNote: 'setup',
+        description: 'Up to 8 agents, advanced workflows, full governance suite',
+        features: ['Everything in Foundation', 'Up to 8 configured agents', 'Advanced workflows', 'Full governance suite', 'Approval chains & budget controls', 'Reporting dashboards'],
+        featured: true,
+    },
+    {
+        name: 'Scale',
+        price: '$12,000–$15,000+',
+        priceNote: 'setup',
+        description: 'Unlimited agents, complex operations, custom integrations',
+        features: ['Everything in Growth', 'Unlimited agents', 'Complex multi-workflow ops', 'Custom integrations', 'Priority support', 'Optional ongoing management'],
+    },
+]
+
+const faqs = [
+    {
+        id: 'faq-1',
+        question: 'What exactly is an "AI company"?',
+        answer: "It's a structured team of AI agents that operates like a real company — with defined roles, task assignments, approval workflows, budgets, and oversight. Instead of using AI as a tool, you're deploying AI as a workforce with governance.",
+    },
+    {
+        id: 'faq-2',
+        question: 'What kinds of tasks can AI agents handle?',
+        answer: 'Content creation, customer support triage, data analysis, research, project coordination, code review, reporting, email drafting, social media management. Most knowledge work that follows repeatable patterns. We help you identify the highest-impact workflows during design.',
+    },
+    {
+        id: 'faq-3',
+        question: 'How much does it cost to run the agents after setup?',
+        answer: "Agent operating costs depend on usage volume and which AI models your agents use. Typical monthly costs range from a few hundred dollars for light usage to a few thousand for heavy operations. We'll give you cost projections during the design phase so there are no surprises.",
+    },
+    {
+        id: 'faq-4',
+        question: 'Do I need to know how to code?',
+        answer: "No. Paperclip is designed for non-technical operators. The management dashboard is visual, and we train you on everything during setup. If you can manage a team of people, you can manage a team of agents.",
+    },
+    {
+        id: 'faq-5',
+        question: 'What happens if an agent makes a mistake?',
+        answer: 'Governance controls catch most issues before they reach anyone. Approval gates require human sign-off on sensitive actions. Budget limits prevent runaway spending. Every action is logged, so you can see exactly what happened and adjust.',
+    },
+]
+
+export default function PaperclipPage() {
+    return (
+        <div className="min-h-screen">
+            {/* Back nav */}
+            <div className="mx-auto max-w-5xl px-6 pt-8">
+                <Link
+                    href={routes.services}
+                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                    <ArrowLeft className="h-4 w-4" />
+                    All services
+                </Link>
+            </div>
+
+            {/* Hero */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <div className="max-w-2xl">
+                        <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">Paperclip AI Company Setup</p>
+                        <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
+                            Build Your AI-Powered Company
+                        </h1>
+                        <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
+                            We set up Paperclip for your business — agent teams, workflows, governance. A structured AI workforce handling real tasks, managed by you.
+                        </p>
+                        <p className="mt-4 text-sm text-muted-foreground">Setup starts at $5,000 · Optional monthly management $1K–$3K/mo</p>
+                        <div className="mt-10">
+                            <ScheduleCallModal
+                                trigger={
+                                    <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
+                                        <span className="text-nowrap">Book a discovery call</span>
+                                        <ChevronRight className="ml-1" />
+                                    </Button>
+                                }
+                            />
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* Context */}
+            <section className="py-16 md:py-24 bg-muted/30">
+                <div className="mx-auto max-w-5xl px-6">
+                    <div className="max-w-3xl">
+                        <h2 className="text-balance text-3xl font-semibold md:text-4xl">Built by the People Who Built Paperclip</h2>
+                        <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
+                            <p>
+                                Paperclip is our platform. When we set up your AI company, you're getting the team that designed the system and runs their own operations on it every day. That's the practical difference between a setup that works and one that needs constant fixing.
+                            </p>
+                            <p>
+                                We're not writing reports about what you could do with AI someday. We're standing up a working system with real agents doing real tasks by the time we hand it over.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* Benefits */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
+                    <div className="mt-12 grid gap-8 md:grid-cols-2">
+                        {benefits.map((benefit, i) => (
+                            <div key={i} className="space-y-3">
+                                <h3 className="text-lg font-semibold">{benefit.title}</h3>
+                                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="mt-12 rounded-2xl border bg-card p-8">
+                        <h3 className="font-semibold">Every engagement includes:</h3>
+                        <ul className="mt-4 space-y-2">
+                            {[
+                                'Company design: we map your operations to an agent team structure that actually makes sense',
+                                'Agent hiring and configuration for your specific workflows',
+                                'Workflow setup: task routing, approval chains, escalation paths, budget controls',
+                                'Governance configuration: permissions, spending limits, oversight dashboards',
+                                'Team training on managing your AI company',
+                                '60 days of management support to get you past the learning curve',
+                            ].map((item) => (
+                                <li key={item} className="flex items-start gap-3 text-sm">
+                                    <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                                    <span className="text-muted-foreground">{item}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </div>
+            </section>
+
+            {/* How it works */}
+            <section className="py-16 md:py-24 bg-muted/30">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
+                    <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
+                        {steps.map((step) => (
+                            <div key={step.number} className="flex gap-8 p-8">
+                                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">{step.number}</p>
+                                <div>
+                                    <h3 className="font-semibold text-lg">{step.title}</h3>
+                                    <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* Pricing */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
+                    <p className="mt-4 text-muted-foreground">All packages include company design, agent setup, workflow configuration, team training, and 60 days post-launch support.</p>
+                    <div className="mt-12 grid gap-6 md:grid-cols-3">
+                        {packages.map((pkg) => (
+                            <Card
+                                key={pkg.name}
+                                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? 'border-2 border-primary' : 'border'}`}
+                            >
+                                {pkg.featured && (
+                                    <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">Most popular</p>
+                                )}
+                                <h3 className="text-xl font-semibold">{pkg.name}</h3>
+                                <div className="mt-2">
+                                    <span className="text-2xl font-bold">{pkg.price}</span>
+                                    {pkg.priceNote && <span className="ml-1 text-sm text-muted-foreground">{pkg.priceNote}</span>}
+                                </div>
+                                <p className="mt-2 text-sm text-muted-foreground">{pkg.description}</p>
+                                <ul className="mt-6 flex-1 space-y-2">
+                                    {pkg.features.map((f) => (
+                                        <li key={f} className="flex items-start gap-2 text-sm">
+                                            <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                                            <span className="text-muted-foreground">{f}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                                <div className="mt-8">
+                                    <ScheduleCallModal
+                                        trigger={
+                                            <Button
+                                                className="w-full"
+                                                variant={pkg.featured ? 'default' : 'outline'}
+                                            >
+                                                Get started
+                                            </Button>
+                                        }
+                                    />
+                                </div>
+                            </Card>
+                        ))}
+                    </div>
+                    <p className="mt-6 text-sm text-muted-foreground text-center">
+                        Optional monthly management: $1,000–$3,000/mo — we handle ongoing optimization, agent additions, and system maintenance.
+                    </p>
+                </div>
+            </section>
+
+            {/* FAQ */}
+            <section className="py-16 md:py-24 bg-muted/30">
+                <div className="mx-auto max-w-5xl px-6">
+                    <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">Common questions</h2>
+                    <div className="mx-auto mt-12 max-w-2xl">
+                        <Accordion type="single" collapsible className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0">
+                            {faqs.map((faq) => (
+                                <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
+                                    <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
+                                        {faq.question}
+                                    </AccordionTrigger>
+                                    <AccordionContent>
+                                        <p className="text-base">{faq.answer}</p>
+                                    </AccordionContent>
+                                </AccordionItem>
+                            ))}
+                        </Accordion>
+                    </div>
+                </div>
+            </section>
+
+            {/* CTA */}
+            <section className="py-16 md:py-24">
+                <div className="mx-auto max-w-5xl px-6">
+                    <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
+                        <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Let's talk about your AI company.</h2>
+                        <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
+                            30-minute call, no commitment. We'll discuss what your operations look like, which agent roles make sense, and what the setup would involve. If Paperclip isn't the right fit, we'll say so.
+                        </p>
+                        <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+                            <ScheduleCallModal
+                                trigger={
+                                    <Button size="lg">
+                                        <span className="text-nowrap">Book a discovery call</span>
+                                        <ChevronRight className="ml-1" />
+                                    </Button>
+                                }
+                            />
+                            <Button asChild variant="outline" size="lg">
+                                <Link href={routes.contact}>Send us a message</Link>
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -69,6 +69,24 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
       priority: 1,
     },
     {
+      url: `${siteConfig.url}${routes.services}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.9,
+    },
+    {
+      url: `${siteConfig.url}${routes.servicesOpenclaw}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.85,
+    },
+    {
+      url: `${siteConfig.url}${routes.servicesPaperclip}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.85,
+    },
+    {
       url: `${siteConfig.url}${routes.features}`,
       lastModified: new Date(),
       changeFrequency: "weekly" as const,

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -33,6 +33,8 @@ export const routes = {
 	features: "/features",
 	pricing: "/pricing",
 	services: "/services",
+	servicesOpenclaw: "/services/openclaw",
+	servicesPaperclip: "/services/paperclip",
 	launch: "/launch",
 
 	// App routes


### PR DESCRIPTION
## Summary

Closes LAC-1734. Adds dedicated landing pages and expanded /services coverage for all new Build And Serve offerings.

- `/services/openclaw` — Full landing page for OpenClaw Setup & Deployment: hero, context, benefits (4), how-it-works (4 steps), pricing tiers (Starter/Professional/Enterprise, $5K–$15K), FAQ, CTA
- `/services/paperclip` — Full landing page for Paperclip AI Company Setup: hero, context, benefits (4), how-it-works (4 steps), pricing tiers (Foundation/Growth/Scale, $5K–$15K+), FAQ, CTA
- `/services` page — Updated with dedicated-offering cards linking to new pages, plus 4 productized service sections (AI Agent Team, ShipKit Launch Package, AI Strategy & Audit, Website Maintenance Retainer)
- Navigation — Services dropdown added to site nav; new routes added to sitemap

## Acceptance Criteria (from LAC-1734)

- [x] Dedicated landing page at /services/openclaw
- [x] Dedicated landing page at /services/paperclip
- [x] New service sections on /services for 4 remaining offerings
- [x] Site navigation updated with Services dropdown
- [ ] Deployed to Vercel (happens on merge via CI)

## Testing Notes

- All pages use existing shadcn/ui components, Tailwind, and ScheduleCallModal
- Pricing tiers follow the copy approved in LAC-1727
- Navigation uses existing route config pattern