### PR TITLE
ci: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,15 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.1.34
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
@@ -45,9 +45,7 @@ jobs:
           fi
 
       - name: Upload Lighthouse Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lighthouse-reports
           path: .lighthouse
-
-


### PR DESCRIPTION
## Summary

GitHub Actions will force Node.js 24 by default starting **June 2nd, 2026**. This upgrades the Lighthouse CI workflow to use Node.js 24-compatible action versions before the deadline.

Changes:
- `actions/checkout@v4` → `@v6`
- `oven-sh/setup-bun@v1` → `@v2`
- `actions/setup-node@v4` → `@v6`
- `actions/upload-artifact@v4` → `@v6`

## Test plan

- [ ] Lighthouse Audit Loop CI passes after merge