### PR TITLE
feat: redesign service landing pages with distinctive visual identity

### DIFF
--- a/src/app/(app)/(main)/services/_components/browser-frame.tsx
+++ b/src/app/(app)/(main)/services/_components/browser-frame.tsx
@@ -1,0 +1,45 @@
+import { BorderBeam } from "@/components/ui/border-beam";
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface BrowserFrameProps {
+  url: string;
+  beamColorFrom: string;
+  beamColorTo: string;
+  className?: string;
+  children: ReactNode;
+}
+
+export function BrowserFrame({
+  url,
+  beamColorFrom,
+  beamColorTo,
+  className,
+  children,
+}: BrowserFrameProps) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-xl border border-white/[0.08] bg-neutral-950 shadow-2xl",
+        className
+      )}
+    >
+      <BorderBeam size={250} colorFrom={beamColorFrom} colorTo={beamColorTo} duration={12} />
+
+      <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-2.5">
+        <div className="flex gap-1.5">
+          <div className="size-2.5 rounded-full bg-[#ff5f57]" />
+          <div className="size-2.5 rounded-full bg-[#febc2e]" />
+          <div className="size-2.5 rounded-full bg-[#28c840]" />
+        </div>
+        <div className="flex flex-1 justify-center">
+          <div className="rounded-md bg-white/[0.06] px-8 py-1">
+            <span className="text-[11px] text-neutral-500">{url}</span>
+          </div>
+        </div>
+      </div>
+
+      {children}
+    </div>
+  );
+}

--- a/src/app/(app)/(main)/services/_components/openclaw-dashboard.tsx
+++ b/src/app/(app)/(main)/services/_components/openclaw-dashboard.tsx
@@ -1,29 +1,14 @@
-import { BorderBeam } from "@/components/ui/border-beam";
 import { cn } from "@/lib/utils";
+import { BrowserFrame } from "./browser-frame";
 
 export function OpenClawDashboard({ className }: { className?: string }) {
   return (
-    <div
-      className={cn(
-        "relative overflow-hidden rounded-xl border border-white/[0.08] bg-neutral-950 shadow-2xl",
-        className
-      )}
+    <BrowserFrame
+      url="app.openclaw.io/dashboard"
+      beamColorFrom="#10b981"
+      beamColorTo="#06b6d4"
+      className={className}
     >
-      <BorderBeam size={250} colorFrom="#10b981" colorTo="#06b6d4" duration={12} />
-
-      <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-2.5">
-        <div className="flex gap-1.5">
-          <div className="size-2.5 rounded-full bg-[#ff5f57]" />
-          <div className="size-2.5 rounded-full bg-[#febc2e]" />
-          <div className="size-2.5 rounded-full bg-[#28c840]" />
-        </div>
-        <div className="flex flex-1 justify-center">
-          <div className="rounded-md bg-white/[0.06] px-8 py-1">
-            <span className="text-[11px] text-neutral-500">app.openclaw.io/dashboard</span>
-          </div>
-        </div>
-      </div>
-
       <div className="grid grid-cols-4 gap-px bg-white/[0.04]">
         {[
           { label: "Active Agents", value: "6", accent: "text-emerald-400" },
@@ -69,6 +54,6 @@ export function OpenClawDashboard({ className }: { className?: string }) {
         </div>
         <span className="text-[10px] text-neutral-600">v2.4.1</span>
       </div>
-    </div>
+    </BrowserFrame>
   );
 }

--- a/src/app/(app)/(main)/services/_components/openclaw-dashboard.tsx
+++ b/src/app/(app)/(main)/services/_components/openclaw-dashboard.tsx
@@ -1,0 +1,74 @@
+import { BorderBeam } from "@/components/ui/border-beam";
+import { cn } from "@/lib/utils";
+
+export function OpenClawDashboard({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-xl border border-white/[0.08] bg-neutral-950 shadow-2xl",
+        className
+      )}
+    >
+      <BorderBeam size={250} colorFrom="#10b981" colorTo="#06b6d4" duration={12} />
+
+      <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-2.5">
+        <div className="flex gap-1.5">
+          <div className="size-2.5 rounded-full bg-[#ff5f57]" />
+          <div className="size-2.5 rounded-full bg-[#febc2e]" />
+          <div className="size-2.5 rounded-full bg-[#28c840]" />
+        </div>
+        <div className="flex flex-1 justify-center">
+          <div className="rounded-md bg-white/[0.06] px-8 py-1">
+            <span className="text-[11px] text-neutral-500">app.openclaw.io/dashboard</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-4 gap-px bg-white/[0.04]">
+        {[
+          { label: "Active Agents", value: "6", accent: "text-emerald-400" },
+          { label: "Tasks Today", value: "147", accent: "text-cyan-400" },
+          { label: "Success Rate", value: "99.2%", accent: "text-emerald-400" },
+          { label: "Avg Response", value: "1.3s", accent: "text-cyan-400" },
+        ].map((m) => (
+          <div key={m.label} className="bg-neutral-950 px-3 py-2">
+            <p className="text-[9px] uppercase tracking-wider text-neutral-600">{m.label}</p>
+            <p className={cn("mt-0.5 text-sm font-semibold", m.accent)}>{m.value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="p-3">
+        <div className="grid grid-cols-3 gap-2">
+          {[
+            { name: "Content Writer", task: "Blog post draft", color: "bg-emerald-400" },
+            { name: "Data Analyst", task: "Q2 revenue report", color: "bg-emerald-400" },
+            { name: "Support Triage", task: "Ticket #1847", color: "bg-amber-400" },
+            { name: "Code Reviewer", task: "PR #423 review", color: "bg-emerald-400" },
+            { name: "Research Bot", task: "Awaiting assignment", color: "bg-neutral-500" },
+            { name: "QA Tester", task: "E2E test suite", color: "bg-emerald-400" },
+          ].map((a) => (
+            <div
+              key={a.name}
+              className="rounded-lg border border-white/[0.04] bg-white/[0.02] p-2.5"
+            >
+              <div className="mb-1 flex items-center gap-1.5">
+                <div className={cn("size-1.5 rounded-full", a.color)} />
+                <span className="text-[11px] font-medium text-neutral-300">{a.name}</span>
+              </div>
+              <p className="truncate text-[10px] text-neutral-600">{a.task}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-white/[0.06] bg-neutral-900/50 px-4 py-1.5">
+        <div className="flex items-center gap-1.5">
+          <div className="size-1.5 animate-pulse rounded-full bg-emerald-400" />
+          <span className="text-[10px] text-neutral-500">All systems operational</span>
+        </div>
+        <span className="text-[10px] text-neutral-600">v2.4.1</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/(main)/services/_components/paperclip-dashboard.tsx
+++ b/src/app/(app)/(main)/services/_components/paperclip-dashboard.tsx
@@ -1,29 +1,14 @@
-import { BorderBeam } from "@/components/ui/border-beam";
 import { cn } from "@/lib/utils";
+import { BrowserFrame } from "./browser-frame";
 
 export function PaperclipDashboard({ className }: { className?: string }) {
   return (
-    <div
-      className={cn(
-        "relative overflow-hidden rounded-xl border border-white/[0.08] bg-neutral-950 shadow-2xl",
-        className
-      )}
+    <BrowserFrame
+      url="app.paperclip.company/dashboard"
+      beamColorFrom="#f59e0b"
+      beamColorTo="#ef4444"
+      className={className}
     >
-      <BorderBeam size={250} colorFrom="#f59e0b" colorTo="#ef4444" duration={12} />
-
-      <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-2.5">
-        <div className="flex gap-1.5">
-          <div className="size-2.5 rounded-full bg-[#ff5f57]" />
-          <div className="size-2.5 rounded-full bg-[#febc2e]" />
-          <div className="size-2.5 rounded-full bg-[#28c840]" />
-        </div>
-        <div className="flex flex-1 justify-center">
-          <div className="rounded-md bg-white/[0.06] px-8 py-1">
-            <span className="text-[11px] text-neutral-500">app.paperclip.company/dashboard</span>
-          </div>
-        </div>
-      </div>
-
       <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2">
         <div>
           <p className="text-xs font-medium text-neutral-200">Acme AI Corp</p>
@@ -107,6 +92,6 @@ export function PaperclipDashboard({ className }: { className?: string }) {
           <span className="text-[10px] text-neutral-600">Governance: Active</span>
         </div>
       </div>
-    </div>
+    </BrowserFrame>
   );
 }

--- a/src/app/(app)/(main)/services/_components/paperclip-dashboard.tsx
+++ b/src/app/(app)/(main)/services/_components/paperclip-dashboard.tsx
@@ -1,0 +1,112 @@
+import { BorderBeam } from "@/components/ui/border-beam";
+import { cn } from "@/lib/utils";
+
+export function PaperclipDashboard({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-xl border border-white/[0.08] bg-neutral-950 shadow-2xl",
+        className
+      )}
+    >
+      <BorderBeam size={250} colorFrom="#f59e0b" colorTo="#ef4444" duration={12} />
+
+      <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-2.5">
+        <div className="flex gap-1.5">
+          <div className="size-2.5 rounded-full bg-[#ff5f57]" />
+          <div className="size-2.5 rounded-full bg-[#febc2e]" />
+          <div className="size-2.5 rounded-full bg-[#28c840]" />
+        </div>
+        <div className="flex flex-1 justify-center">
+          <div className="rounded-md bg-white/[0.06] px-8 py-1">
+            <span className="text-[11px] text-neutral-500">app.paperclip.company/dashboard</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2">
+        <div>
+          <p className="text-xs font-medium text-neutral-200">Acme AI Corp</p>
+          <p className="text-[10px] text-neutral-600">3 departments &middot; 8 agents</p>
+        </div>
+        <div className="rounded-full bg-amber-500/10 px-2 py-0.5">
+          <span className="text-[10px] font-medium text-amber-400">Growth Plan</span>
+        </div>
+      </div>
+
+      <div className="p-3">
+        <div className="mb-3 grid grid-cols-3 gap-2">
+          {[
+            {
+              dept: "Marketing",
+              agents: 3,
+              tasks: 42,
+              spend: "$1.2K",
+              border: "border-l-amber-400",
+            },
+            {
+              dept: "Engineering",
+              agents: 3,
+              tasks: 28,
+              spend: "$800",
+              border: "border-l-blue-400",
+            },
+            {
+              dept: "Operations",
+              agents: 2,
+              tasks: 35,
+              spend: "$600",
+              border: "border-l-emerald-400",
+            },
+          ].map((d) => (
+            <div
+              key={d.dept}
+              className={cn(
+                "rounded-lg border border-white/[0.04] border-l-2 bg-white/[0.02] p-2.5",
+                d.border
+              )}
+            >
+              <p className="text-[11px] font-medium text-neutral-300">{d.dept}</p>
+              <div className="mt-1.5 space-y-0.5 text-[10px]">
+                <p className="text-neutral-600">
+                  {d.agents} agents &middot; {d.tasks} tasks
+                </p>
+                <p className="text-amber-400/80">{d.spend}/mo</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="rounded-lg bg-white/[0.03] p-2.5">
+          <p className="mb-2 text-[10px] text-neutral-600">Budget Utilization</p>
+          <div className="space-y-1.5">
+            {[
+              { label: "Marketing", pct: 78, color: "bg-amber-400" },
+              { label: "Engineering", pct: 52, color: "bg-blue-400" },
+              { label: "Operations", pct: 65, color: "bg-emerald-400" },
+            ].map((bar) => (
+              <div key={bar.label} className="flex items-center gap-2">
+                <span className="w-14 shrink-0 text-[9px] text-neutral-600">{bar.label}</span>
+                <div className="h-1 flex-1 rounded-full bg-white/[0.06]">
+                  <div
+                    className={cn("h-full rounded-full", bar.color)}
+                    style={{ width: `${bar.pct}%` }}
+                  />
+                </div>
+                <span className="w-6 text-right text-[9px] text-neutral-600">{bar.pct}%</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-white/[0.06] bg-neutral-900/50 px-4 py-1.5">
+        <span className="text-[10px] text-neutral-500">Total: $2,600/mo</span>
+        <div className="flex items-center gap-1.5">
+          <div className="size-1.5 rounded-full bg-emerald-400" />
+          <span className="text-[10px] text-neutral-600">Governance: Active</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/(main)/services/_components/services-faq.tsx
+++ b/src/app/(app)/(main)/services/_components/services-faq.tsx
@@ -1,69 +1,81 @@
-'use client'
+"use client";
 
-import Link from 'next/link'
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
-import { routes } from '@/config/routes'
+import Link from "next/link";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { routes } from "@/config/routes";
 
 const faqs = [
-    {
-        id: 'faq-1',
-        question: 'How long does a typical project take?',
-        answer: 'A focused MVP is usually three to six weeks. A larger platform build can run three to six months. We scope it honestly during the discovery call.',
-    },
-    {
-        id: 'faq-2',
-        question: 'Do you work with non-technical founders?',
-        answer: 'Yes. Part of the job is translating between what you want to build and what it actually takes to build it.',
-    },
-    {
-        id: 'faq-3',
-        question: 'What does the process look like?',
-        answer: 'Discovery call, written proposal with scope and cost, then two-week sprints with demos. You always know where things stand.',
-    },
-    {
-        id: 'faq-4',
-        question: 'Do you handle design?',
-        answer: "We can work from your designs, and we handle basic UI work ourselves. For complex product design, we'll tell you if you need a dedicated designer and can point you toward people we trust.",
-    },
-    {
-        id: 'faq-5',
-        question: 'Can I hire you just for consulting?',
-        answer: 'Yes. Consulting and architecture reviews are available without a full build engagement.',
-    },
-]
+  {
+    id: "faq-1",
+    question: "How long does a typical project take?",
+    answer:
+      "A focused MVP is usually three to six weeks. A larger platform build can run three to six months. We scope it honestly during the discovery call.",
+  },
+  {
+    id: "faq-2",
+    question: "Do you work with non-technical founders?",
+    answer:
+      "Yes. Part of the job is translating between what you want to build and what it actually takes to build it.",
+  },
+  {
+    id: "faq-3",
+    question: "What does the process look like?",
+    answer:
+      "Discovery call, written proposal with scope and cost, then two-week sprints with demos. You always know where things stand.",
+  },
+  {
+    id: "faq-4",
+    question: "Do you handle design?",
+    answer:
+      "We can work from your designs, and we handle basic UI work ourselves. For complex product design, we'll tell you if you need a dedicated designer and can point you toward people we trust.",
+  },
+  {
+    id: "faq-5",
+    question: "Can I hire you just for consulting?",
+    answer:
+      "Yes. Consulting and architecture reviews are available without a full build engagement.",
+  },
+];
 
 export function ServicesFaq() {
-    return (
-        <section className="py-16 md:py-24">
-            <div className="mx-auto max-w-5xl px-6">
-                <div className="mx-auto max-w-xl text-center">
-                    <h2 className="text-balance text-3xl font-bold md:text-4xl">Frequently asked questions</h2>
-                </div>
-                <div className="mx-auto mt-12 max-w-xl">
-                    <Accordion
-                        type="single"
-                        collapsible
-                        className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0"
-                    >
-                        {faqs.map((item) => (
-                            <AccordionItem key={item.id} value={item.id} className="border-dashed">
-                                <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
-                                    {item.question}
-                                </AccordionTrigger>
-                                <AccordionContent>
-                                    <p className="text-base">{item.answer}</p>
-                                </AccordionContent>
-                            </AccordionItem>
-                        ))}
-                    </Accordion>
-                    <p className="mt-6 px-8 text-center text-muted-foreground">
-                        Still have questions?{' '}
-                        <Link href={routes.contact} className="font-medium text-primary hover:underline">
-                            Get in touch
-                        </Link>
-                    </p>
-                </div>
-            </div>
-        </section>
-    )
+  return (
+    <section className="py-16 md:py-24">
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="mx-auto max-w-xl text-center">
+          <h2 className="text-balance text-3xl font-bold md:text-4xl">
+            Frequently asked questions
+          </h2>
+        </div>
+        <div className="mx-auto mt-12 max-w-xl">
+          <Accordion
+            type="single"
+            collapsible
+            className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0"
+          >
+            {faqs.map((item) => (
+              <AccordionItem key={item.id} value={item.id} className="border-dashed">
+                <AccordionTrigger className="cursor-pointer text-base hover:no-underline">
+                  {item.question}
+                </AccordionTrigger>
+                <AccordionContent>
+                  <p className="text-base">{item.answer}</p>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+          <p className="mt-6 px-8 text-center text-muted-foreground">
+            Still have questions?{" "}
+            <Link href={routes.contact} className="font-medium text-primary hover:underline">
+              Get in touch
+            </Link>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/app/(app)/(main)/services/openclaw/page.tsx
+++ b/src/app/(app)/(main)/services/openclaw/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Check, ChevronRight } from "lucide-react";
+import { ArrowLeft, Check, ChevronRight, Headphones, Network, Shield, Zap } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ScheduleCallModal } from "@/components/modals/schedule-call-modal";
@@ -8,10 +8,14 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import AnimatedGradientText from "@/components/ui/animated-gradient-text";
+import { BorderBeam } from "@/components/ui/border-beam";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import RetroGrid from "@/components/ui/retro-grid";
+import { TextEffect } from "@/components/ui/text-effect";
 import { constructMetadata } from "@/config/metadata";
 import { routes } from "@/config/routes";
+import { OpenClawDashboard } from "../_components/openclaw-dashboard";
 
 export const metadata: Metadata = constructMetadata({
   title: "OpenClaw Setup & Deployment | Build And Serve",
@@ -19,11 +23,38 @@ export const metadata: Metadata = constructMetadata({
     "Deploy AI agent orchestration with OpenClaw. We handle architecture, configuration, agent design, deployment, and training. $5K–$15K project-based.",
 });
 
+const benefits = [
+  {
+    icon: Network,
+    title: "Architecture That Holds Up",
+    body: "Most agent deployments fail because the architecture was wrong from the start. We design your agent topology based on what actually works in production, not what looks good in a demo.",
+    gradient: "from-emerald-500 to-cyan-500",
+  },
+  {
+    icon: Zap,
+    title: "Deployed in Weeks, Not Months",
+    body: "A typical OpenClaw deployment takes 2–4 weeks from kickoff to production. We know the critical path and where teams waste time.",
+    gradient: "from-cyan-500 to-blue-500",
+  },
+  {
+    icon: Shield,
+    title: "You Own Everything",
+    body: "No vendor lock-in, no proprietary wrapper. Your OpenClaw instance runs on your infrastructure, your accounts, your control.",
+    gradient: "from-blue-500 to-emerald-500",
+  },
+  {
+    icon: Headphones,
+    title: "30 Days of Post-Launch Support",
+    body: "The first month after deployment is when the real questions come up. Bug fixes, configuration adjustments, agent tuning. We’re there for it.",
+    gradient: "from-emerald-500 to-teal-500",
+  },
+];
+
 const steps = [
   {
     number: "01",
     title: "Discovery",
-    body: "60-minute call to understand your use case, your team, and what you want your agents doing. We'll tell you honestly whether OpenClaw is the right fit or if something simpler would work.",
+    body: "60-minute call to understand your use case, your team, and what you want your agents doing. We’ll tell you honestly whether OpenClaw is the right fit or if something simpler would work.",
   },
   {
     number: "02",
@@ -39,25 +70,6 @@ const steps = [
     number: "04",
     title: "Training & Handoff",
     body: "Your team gets hands-on training. We cover day-to-day management, adding new agents, troubleshooting, and extending the system. Plus 30 days of support after handoff.",
-  },
-];
-
-const benefits = [
-  {
-    title: "Architecture That Holds Up",
-    body: "Most agent deployments fail because the architecture was wrong from the start. We design your agent topology based on what actually works in production, not what looks good in a demo.",
-  },
-  {
-    title: "Deployed in Weeks, Not Months",
-    body: "A typical OpenClaw deployment takes 2–4 weeks from kickoff to production. We know the critical path and where teams waste time.",
-  },
-  {
-    title: "You Own Everything",
-    body: "No vendor lock-in, no proprietary wrapper. Your OpenClaw instance runs on your infrastructure, your accounts, your control.",
-  },
-  {
-    title: "30 Days of Post-Launch Support",
-    body: "The first month after deployment is when the real questions come up. Bug fixes, configuration adjustments, agent tuning. We're there for it.",
   },
 ];
 
@@ -124,71 +136,91 @@ const faqs = [
     id: "faq-4",
     question: "Can I add more agents later?",
     answer:
-      "Yes. We design the architecture so adding agents later doesn't require rebuilding what's already there. You can add them yourself after training, or bring us back for more complex additions.",
+      "Yes. We design the architecture so adding agents later doesn’t require rebuilding what’s already there. You can add them yourself after training, or bring us back for more complex additions.",
   },
   {
     id: "faq-5",
     question: "How is this different from just using ChatGPT or Claude directly?",
     answer:
-      "Direct AI usage is one person talking to one model. OpenClaw orchestration is multiple specialized agents coordinating on complex tasks — with monitoring, failure handling, and quality controls. It's the difference between asking someone a question and having a team work on a project.",
+      "Direct AI usage is one person talking to one model. OpenClaw orchestration is multiple specialized agents coordinating on complex tasks — with monitoring, failure handling, and quality controls. It’s the difference between asking someone a question and having a team work on a project.",
   },
 ];
 
 export default function OpenClawPage() {
   return (
     <div className="min-h-screen">
-      {/* Back nav */}
-      <div className="mx-auto max-w-5xl px-6 pt-8">
-        <Link
-          href={routes.services}
-          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          All services
-        </Link>
-      </div>
-
       {/* Hero */}
-      <section className="py-16 md:py-24">
-        <div className="mx-auto max-w-5xl px-6">
-          <div className="max-w-2xl">
-            <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
-              OpenClaw Setup & Deployment
-            </p>
-            <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
-              Deploy AI Agent Teams That Actually Work
-            </h1>
-            <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
-              We set up OpenClaw agent orchestration for your business — architecture, deployment,
-              training. Your agents coordinating on real tasks in weeks, not months.
-            </p>
-            <p className="mt-4 text-sm text-muted-foreground">Starting at $5,000</p>
-            <div className="mt-10">
-              <ScheduleCallModal
-                trigger={
-                  <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
-                    <span className="text-nowrap">Book a discovery call</span>
-                    <ChevronRight className="ml-1" />
-                  </Button>
-                }
-              />
+      <section className="relative overflow-hidden bg-neutral-950 pb-20 pt-8 md:pb-28">
+        <RetroGrid className="opacity-20" />
+        <div className="relative mx-auto max-w-7xl px-6">
+          <Link
+            href={routes.services}
+            className="mb-12 inline-flex items-center gap-2 text-sm text-neutral-500 transition-colors hover:text-neutral-300"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            All services
+          </Link>
+
+          <div className="lg:grid lg:grid-cols-2 lg:items-center lg:gap-16">
+            <div>
+              <AnimatedGradientText className="mb-6">
+                <span className="text-neutral-200">OpenClaw Setup &amp; Deployment</span>
+              </AnimatedGradientText>
+
+              <TextEffect
+                preset="fade-in-blur"
+                speedSegment={0.3}
+                as="h1"
+                className="text-balance text-4xl font-semibold text-white sm:text-5xl md:text-6xl"
+              >
+                Deploy AI Agent Teams That Actually Work
+              </TextEffect>
+
+              <p className="mt-6 max-w-lg text-balance text-lg text-neutral-400">
+                We set up OpenClaw agent orchestration for your business &mdash; architecture,
+                deployment, training. Your agents coordinating on real tasks in weeks, not months.
+              </p>
+
+              <p className="mt-4 text-sm text-neutral-500">Starting at $5,000</p>
+
+              <div className="mt-8">
+                <ScheduleCallModal
+                  trigger={
+                    <Button
+                      size="lg"
+                      className="h-12 rounded-full bg-emerald-600 pl-5 pr-3 text-base text-white hover:bg-emerald-500"
+                    >
+                      <span className="text-nowrap">Book a discovery call</span>
+                      <ChevronRight className="ml-1" />
+                    </Button>
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="mt-12 lg:mt-0">
+              <div className="relative">
+                <div className="absolute -inset-4 rounded-2xl bg-gradient-to-br from-emerald-500/20 via-transparent to-cyan-500/20 blur-2xl" />
+                <OpenClawDashboard className="relative" />
+              </div>
             </div>
           </div>
         </div>
       </section>
 
       {/* Context */}
-      <section className="py-16 md:py-24 bg-muted/30">
+      <section className="bg-muted/30 py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <div className="max-w-3xl">
+          <div className="max-w-3xl border-l-2 border-emerald-500/50 pl-8">
             <h2 className="text-balance text-3xl font-semibold md:text-4xl">
               We Build Agent Systems. This Is What We Do.
             </h2>
-            <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
+            <div className="mt-6 space-y-4 leading-relaxed text-muted-foreground">
               <p>
-                We didn't learn OpenClaw from a tutorial. We've built agent orchestration tools,
-                shipped them to production, and run our own multi-agent teams daily. When we deploy
-                OpenClaw for you, we're drawing on problems we've already solved on our own systems.
+                We didn&apos;t learn OpenClaw from a tutorial. We&apos;ve built agent orchestration
+                tools, shipped them to production, and run our own multi-agent teams daily. When we
+                deploy OpenClaw for you, we&apos;re drawing on problems we&apos;ve already solved on
+                our own systems.
               </p>
               <p>
                 Juno, Lacy Shell, our own internal agent teams all run on these same patterns. We
@@ -204,26 +236,36 @@ export default function OpenClawPage() {
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
           <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
-          <div className="mt-12 grid gap-8 md:grid-cols-2">
-            {benefits.map((benefit) => (
-              <div key={benefit.title} className="space-y-3">
-                <h3 className="text-lg font-semibold">{benefit.title}</h3>
-                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
+            {benefits.map((b) => (
+              <div
+                key={b.title}
+                className="group relative overflow-hidden rounded-2xl border bg-card p-8 transition-shadow hover:shadow-lg"
+              >
+                <div className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${b.gradient}`} />
+                <b.icon className="mb-4 h-10 w-10 text-emerald-500/80" />
+                <h3 className="text-lg font-semibold">{b.title}</h3>
+                <p className="mt-3 leading-relaxed text-muted-foreground">{b.body}</p>
               </div>
             ))}
           </div>
-          <div className="mt-12 rounded-2xl border bg-card p-8">
-            <h3 className="font-semibold">Every engagement includes:</h3>
-            <ul className="mt-4 space-y-2">
+
+          <div className="relative mt-12 overflow-hidden rounded-2xl border bg-card p-8">
+            <BorderBeam colorFrom="#10b981" colorTo="#06b6d4" duration={20} />
+            <h3 className="text-lg font-semibold">Every engagement includes:</h3>
+            <ul className="mt-4 grid gap-2 sm:grid-cols-2">
               {[
                 "Architecture review and agent design",
-                "Full OpenClaw deployment (infrastructure, configuration, security, monitoring)",
-                "Custom agent development for your specific workflows",
-                "Training for your team on managing and extending the system",
+                "Full OpenClaw deployment and configuration",
+                "Security model and access controls",
+                "Monitoring and alerting setup",
+                "Custom agent development for your workflows",
+                "Team training on managing the system",
                 "30 days of post-deployment support",
+                "Documentation for your team",
               ].map((item) => (
                 <li key={item} className="flex items-start gap-3 text-sm">
-                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
                   <span className="text-muted-foreground">{item}</span>
                 </li>
               ))}
@@ -232,20 +274,18 @@ export default function OpenClawPage() {
         </div>
       </section>
 
-      {/* How it works */}
-      <section className="py-16 md:py-24 bg-muted/30">
+      {/* Process */}
+      <section className="bg-muted/30 py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
           <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
-          <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
             {steps.map((step) => (
-              <div key={step.number} className="flex gap-8 p-8">
-                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">
+              <div key={step.number} className="rounded-2xl border bg-card p-8">
+                <span className="bg-gradient-to-br from-emerald-400 to-cyan-400 bg-clip-text text-4xl font-bold text-transparent">
                   {step.number}
-                </p>
-                <div>
-                  <h3 className="font-semibold text-lg">{step.title}</h3>
-                  <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
-                </div>
+                </span>
+                <h3 className="mt-4 text-lg font-semibold">{step.title}</h3>
+                <p className="mt-3 leading-relaxed text-muted-foreground">{step.body}</p>
               </div>
             ))}
           </div>
@@ -262,14 +302,21 @@ export default function OpenClawPage() {
           </p>
           <div className="mt-12 grid gap-6 md:grid-cols-3">
             {packages.map((pkg) => (
-              <Card
+              <div
                 key={pkg.name}
-                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? "border-2 border-primary" : "border"}`}
+                className={`relative flex flex-col overflow-hidden rounded-2xl border p-8 ${
+                  pkg.featured
+                    ? "border-emerald-500/50 shadow-[0_0_30px_-5px_rgba(16,185,129,0.15)]"
+                    : ""
+                }`}
               >
                 {pkg.featured && (
-                  <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">
-                    Most popular
-                  </p>
+                  <>
+                    <BorderBeam colorFrom="#10b981" colorTo="#06b6d4" size={150} duration={10} />
+                    <p className="mb-4 text-xs font-medium uppercase tracking-widest text-emerald-500">
+                      Most popular
+                    </p>
+                  </>
                 )}
                 <h3 className="text-xl font-semibold">{pkg.name}</h3>
                 <p className="mt-2 text-2xl font-bold">{pkg.price}</p>
@@ -277,7 +324,7 @@ export default function OpenClawPage() {
                 <ul className="mt-6 flex-1 space-y-2">
                   {pkg.features.map((f) => (
                     <li key={f} className="flex items-start gap-2 text-sm">
-                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
                       <span className="text-muted-foreground">{f}</span>
                     </li>
                   ))}
@@ -291,26 +338,26 @@ export default function OpenClawPage() {
                     }
                   />
                 </div>
-              </Card>
+              </div>
             ))}
           </div>
-          <p className="mt-6 text-sm text-muted-foreground text-center">
+          <p className="mt-6 text-center text-sm text-muted-foreground">
             Optional ongoing support retainer available after any package.
           </p>
         </div>
       </section>
 
       {/* FAQ */}
-      <section className="py-16 md:py-24 bg-muted/30">
+      <section className="bg-muted/30 py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">
+          <h2 className="text-balance text-center text-3xl font-semibold md:text-4xl">
             Common questions
           </h2>
           <div className="mx-auto mt-12 max-w-2xl">
             <Accordion
               type="single"
               collapsible
-              className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0"
+              className="ring-muted w-full rounded-2xl border bg-card px-8 py-3 shadow-sm ring-4 dark:ring-0"
             >
               {faqs.map((faq) => (
                 <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
@@ -330,25 +377,35 @@ export default function OpenClawPage() {
       {/* CTA */}
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
-            <h2 className="text-balance text-4xl font-semibold lg:text-5xl">Ready to deploy?</h2>
-            <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
-              Most projects start with a 30-minute call — no commitment, just a conversation about
-              what you're trying to automate and whether OpenClaw is the right approach. If it's
-              not, we'll tell you.
-            </p>
-            <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
-              <ScheduleCallModal
-                trigger={
-                  <Button size="lg">
-                    <span className="text-nowrap">Book a discovery call</span>
-                    <ChevronRight className="ml-1" />
-                  </Button>
-                }
-              />
-              <Button asChild variant="outline" size="lg">
-                <Link href={routes.contact}>Send us a message</Link>
-              </Button>
+          <div className="relative overflow-hidden rounded-3xl border bg-neutral-950 px-6 py-16 text-center md:py-24">
+            <RetroGrid className="opacity-15" />
+            <div className="relative">
+              <h2 className="text-balance text-4xl font-semibold text-white lg:text-5xl">
+                Ready to deploy?
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-neutral-400">
+                Most projects start with a 30-minute call &mdash; no commitment, just a conversation
+                about what you&apos;re trying to automate and whether OpenClaw is the right
+                approach. If it&apos;s not, we&apos;ll tell you.
+              </p>
+              <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+                <ScheduleCallModal
+                  trigger={
+                    <Button size="lg" className="bg-emerald-600 text-white hover:bg-emerald-500">
+                      <span className="text-nowrap">Book a discovery call</span>
+                      <ChevronRight className="ml-1" />
+                    </Button>
+                  }
+                />
+                <Button
+                  asChild
+                  variant="outline"
+                  size="lg"
+                  className="border-neutral-700 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+                >
+                  <Link href={routes.contact}>Send us a message</Link>
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/(app)/(main)/services/page.tsx
+++ b/src/app/(app)/(main)/services/page.tsx
@@ -3,8 +3,12 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ScheduleCallModal } from "@/components/modals/schedule-call-modal";
 import { Badge } from "@/components/ui/badge";
+import { BorderBeam } from "@/components/ui/border-beam";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import NumberTicker from "@/components/ui/number-ticker";
+import RetroGrid from "@/components/ui/retro-grid";
+import { TextEffect } from "@/components/ui/text-effect";
 import { constructMetadata } from "@/config/metadata";
 import { routes } from "@/config/routes";
 import { ServicesFaq } from "./_components/services-faq";
@@ -19,34 +23,34 @@ const services = [
   {
     id: "nextjs",
     title: "Next.js and React development",
-    body: "We've been building with React since early versions and Next.js since it became the obvious choice for production web apps. We know where projects go wrong, how to structure things for teams that grow, and how to ship something you won't have to rebuild in a year.",
+    body: "We’ve been building with React since early versions and Next.js since it became the obvious choice for production web apps. We know where projects go wrong, how to structure things for teams that grow, and how to ship something you won’t have to rebuild in a year.",
     goodFor: "SaaS products, startup MVPs, customer portals, marketing sites that need to perform",
   },
   {
     id: "fullstack",
     title: "Full-stack web applications",
-    body: "Frontend to backend, database to deployment. We handle the whole stack so you're not coordinating five different contractors or explaining the same context to each one. That includes API design, database architecture, authentication, payments, background jobs — whatever your product needs to work.",
+    body: "Frontend to backend, database to deployment. We handle the whole stack so you’re not coordinating five different contractors or explaining the same context to each one. That includes API design, database architecture, authentication, payments, background jobs — whatever your product needs to work.",
     goodFor:
       "Greenfield builds, platform redesigns, teams that need one person to own the whole thing",
   },
   {
     id: "ai",
     title: "AI integration and automation",
-    body: "We built our own AI desktop app (Juno) and AI terminal (Lacy Shell) in-house, so we understand AI integration from the inside. We know the difference between an integration that solves a real problem and one that just adds a line to the feature list. For client work, that means LLM-powered features that earn their place, agent workflows, internal automation that replaces manual processes, and RAG pipelines when search needs to get smarter.",
+    body: "We built our own AI desktop app (Juno) and AI terminal (Lacy Shell) in-house, so we understand AI integration from the inside. We know the difference between an integration that solves a real problem and one that just adds a line to the feature list.",
     goodFor:
       "Product AI features, back-office automation, LLM-powered tools, custom agent workflows",
   },
   {
     id: "performance",
     title: "Site speed and performance optimization",
-    body: "Slow sites lose money. Load time directly affects conversions. We audit what's actually slowing you down, then fix it: rendering strategy, image handling, caching, CDN setup, code splitting. We tell you what will actually move the metric before touching anything.",
+    body: "Slow sites lose money. Load time directly affects conversions. We audit what’s actually slowing you down, then fix it: rendering strategy, image handling, caching, CDN setup, code splitting.",
     goodFor:
       "Sites with high traffic and dropping conversions, platforms that have scaled past their original architecture",
   },
   {
     id: "api",
     title: "API development and integrations",
-    body: "Whether you're building the API or connecting to someone else's, we do both well. Clean design, proper versioning, reliable performance under load. We've integrated enough third-party APIs to know which documentation misleads you and where the edge cases live.",
+    body: "Whether you’re building the API or connecting to someone else’s, we do both well. Clean design, proper versioning, reliable performance under load.",
     goodFor: "Third-party integrations, webhook systems, internal API layers, data pipelines",
   },
 ];
@@ -56,40 +60,36 @@ const productizedServices = [
     id: "agent-team",
     title: "AI Agent Team — Managed Service",
     badge: "Managed",
-    body: "We deploy, manage, and optimize AI agent teams that do real work for your business. Content creation, customer support triage, data analysis, research, reporting. We run it, you get the results. Includes ongoing management, weekly reporting on output volume and quality, and monthly strategy reviews.",
+    body: "We deploy, manage, and optimize AI agent teams that do real work for your business. Content creation, customer support triage, data analysis, research, reporting. We run it, you get the results.",
     goodFor:
       "Operations leaders at SMBs drowning in manual processes. Marketing teams that need steady content production without hiring.",
     pricing: "$2K–$10K/month depending on scope",
-    href: routes.services,
   },
   {
     id: "shipkit",
     title: "ShipKit Launch Package",
     badge: "Fixed Price",
-    body: "ShipKit is our production-grade Next.js framework. The Launch Package means you don't buy a boilerplate and figure it out yourself. We build your app on ShipKit, customize it for your brand and use case, and hand you a deployed product in 1–2 weeks. Full source code handoff. No lock-in.",
+    body: "ShipKit is our production-grade Next.js framework. The Launch Package means you don’t buy a boilerplate and figure it out yourself. We build your app on ShipKit, customize it for your brand and use case, and hand you a deployed product in 1–2 weeks.",
     goodFor:
       "Solo founders who need to ship now. Early-stage startups validating with a real product instead of a mockup.",
     pricing: "$2K–$5K standard · $7K–$10K Pro",
-    href: routes.services,
   },
   {
     id: "ai-audit",
     title: "AI Strategy & Audit",
     badge: "Fixed Price",
-    body: "We look at your operations, your team, your tools, and your bottlenecks. Then we tell you where AI saves real time and money. Not theoretical possibilities. Practical implementations you can act on in the next 90 days. You get a written report and 60-day action plan — not a 50-page deck that sits in a drawer.",
+    body: "We look at your operations, your team, your tools, and your bottlenecks. Then we tell you where AI saves real time and money. Not theoretical possibilities. Practical implementations you can act on in the next 90 days.",
     goodFor:
-      'Business owners who know AI matters but aren\'t sure where to start. Ops managers tasked with "figure out AI for us."',
+      "Business owners who know AI matters but aren’t sure where to start. Ops managers tasked with figuring out AI.",
     pricing: "$1K–$3K · most land around $1,500–$2,000",
-    href: routes.services,
   },
   {
     id: "maintenance",
     title: "Website Maintenance & Support Retainer",
     badge: "Monthly",
-    body: "You built something. Now someone needs to keep it running. Dependencies need updates. Security patches need applying. Performance needs monitoring. Features need tweaking. We handle all of it on a monthly retainer. Essentials starts at $500/mo. Growth adds performance optimization and feature hours. Scale includes dedicated support and AI-powered monitoring.",
+    body: "You built something. Now someone needs to keep it running. Dependencies, security patches, performance, feature tweaks. We handle all of it on a monthly retainer.",
     goodFor: "Any business running a Next.js or React app without a dedicated dev team.",
     pricing: "$500–$3K/month · three tiers",
-    href: routes.services,
   },
 ];
 
@@ -99,33 +99,36 @@ const caseStudies = [
     title: "ShipKit",
     subtitle: "Next.js application framework",
     problem:
-      "Every new web app started with the same two weeks of setup: authentication, database connections, billing, email, multi-tenant architecture. All before writing a single line of actual product code.",
+      "Every new web app started with the same two weeks of setup: authentication, database connections, billing, email, multi-tenant architecture.",
     solution:
-      "Built ShipKit, a production-ready Next.js boilerplate with all of it included from the start. Auth, Stripe payments, a CMS layer, multi-tenant support, and a component library. Open source.",
+      "Built ShipKit, a production-ready Next.js boilerplate with all of it included from the start. Auth, Stripe payments, a CMS layer, multi-tenant support, and a component library.",
     outcome:
-      "Developers skip the setup phase entirely. Projects that used to take two weeks to get off the ground now start shipping product features from day one. Thousands of developers use the kit globally.",
+      "Developers skip the setup phase entirely. Projects that used to take two weeks now ship product features from day one.",
+    gradient: "from-blue-500 to-violet-500",
   },
   {
     id: "juno",
     title: "Juno",
     subtitle: "AI desktop application",
     problem:
-      "AI computer use needed a native interface that ran at desktop speed. Browser-based wrappers were sluggish and added overhead for a tool people would use constantly.",
+      "AI computer use needed a native interface that ran at desktop speed. Browser-based wrappers were sluggish.",
     solution:
-      "Built Juno from scratch in Rust with Tauri, a native Mac application that integrates directly with Claude Computer Use. The engineering focus was keeping the interface responsive while the AI was working in the background.",
+      "Built Juno from scratch in Rust with Tauri, a native Mac application that integrates directly with Claude Computer Use.",
     outcome:
-      "A native AI desktop agent that handles computer use tasks without the performance hit of a browser wrapper. Shipped as a full product, not a prototype.",
+      "A native AI desktop agent that handles computer use tasks without the performance hit of a browser wrapper.",
+    gradient: "from-emerald-500 to-cyan-500",
   },
   {
     id: "lacy-shell",
     title: "Lacy Shell",
     subtitle: "AI terminal",
     problem:
-      "AI-assisted development meant constant context switching: work in the terminal, copy to an AI chat window, paste back, repeat. The two tools never talked to each other.",
+      "AI-assisted development meant constant context switching: work in the terminal, copy to an AI chat window, paste back, repeat.",
     solution:
-      "Built Lacy Shell as a ZSH/Bash plugin that routes commands between the shell and AI agents based on what you're doing. No new terminal to learn, it works inside your existing setup.",
+      "Built Lacy Shell as a ZSH/Bash plugin that routes commands between the shell and AI agents based on what you’re doing.",
     outcome:
-      "AI assistance built into the terminal itself. Developers get context-aware AI help without leaving the command line. Available at lacy.sh.",
+      "AI assistance built into the terminal itself. Developers get context-aware AI help without leaving the command line.",
+    gradient: "from-orange-500 to-red-500",
   },
 ];
 
@@ -136,23 +139,132 @@ export default function ServicesPage() {
       <section className="py-24 md:py-32">
         <div className="mx-auto max-w-5xl px-6">
           <div className="max-w-2xl">
-            <h1 className="text-balance text-5xl font-semibold md:text-6xl lg:text-7xl">
+            <TextEffect
+              preset="fade-in-blur"
+              speedSegment={0.3}
+              as="h1"
+              className="text-balance text-5xl font-semibold md:text-6xl lg:text-7xl"
+            >
               We handle the technical side. You focus on everything else.
-            </h1>
+            </TextEffect>
             <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
               20 years of full-stack development. Built tools used by thousands of developers,
               integrated AI into production apps, and shipped fast for clients who needed to move.
             </p>
-            <div className="mt-12">
-              <ScheduleCallModal
-                trigger={
-                  <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
-                    <span className="text-nowrap">Start a project</span>
-                    <ChevronRight className="ml-1" />
-                  </Button>
-                }
-              />
-            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="mt-16 grid grid-cols-2 gap-8 border-t pt-12 md:grid-cols-4">
+            {[
+              { value: 20, suffix: "+", label: "Years Experience" },
+              { value: 50, suffix: "+", label: "Projects Delivered" },
+              { value: 9, suffix: "", label: "Enterprise Clients" },
+              { value: 30, suffix: "min", label: "Free Discovery Call" },
+            ].map((stat) => (
+              <div key={stat.label}>
+                <p className="text-4xl font-bold">
+                  <NumberTicker value={stat.value} className="text-4xl font-bold" />
+                  <span className="text-muted-foreground">{stat.suffix}</span>
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">{stat.label}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-12">
+            <ScheduleCallModal
+              trigger={
+                <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
+                  <span className="text-nowrap">Start a project</span>
+                  <ChevronRight className="ml-1" />
+                </Button>
+              }
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Offerings */}
+      <section className="bg-muted/30 py-16 md:py-24">
+        <div className="mx-auto max-w-5xl px-6">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
+              Dedicated offerings
+            </p>
+            <h2 className="mt-3 text-balance text-3xl font-semibold md:text-4xl">
+              Productized services with clear scope and pricing
+            </h2>
+          </div>
+
+          <div className="mt-12 grid gap-6 md:grid-cols-2">
+            <Link
+              href="/services/openclaw"
+              className="group relative overflow-hidden rounded-2xl border bg-card p-8 transition-shadow hover:shadow-xl"
+            >
+              <div className="absolute inset-x-0 top-0 h-1.5 bg-gradient-to-r from-emerald-500 to-cyan-500" />
+              <div className="absolute right-0 top-0 h-32 w-32 rounded-bl-full bg-gradient-to-bl from-emerald-500/10 to-transparent" />
+              <div className="relative">
+                <p className="text-xs font-medium uppercase tracking-widest text-emerald-500">
+                  AI Agent Orchestration
+                </p>
+                <h3 className="mt-2 text-xl font-semibold">OpenClaw Setup &amp; Deployment</h3>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                  Multi-agent systems deployed and running. Architecture, configuration, training.
+                  We know where setups go wrong because we run agent teams ourselves.
+                </p>
+                <p className="mt-4 text-sm font-medium">$5K–$15K project-based</p>
+                <div className="mt-6 flex items-center gap-1 text-sm font-medium text-emerald-500">
+                  View full details
+                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                </div>
+              </div>
+            </Link>
+
+            <Link
+              href="/services/paperclip"
+              className="group relative overflow-hidden rounded-2xl border bg-card p-8 transition-shadow hover:shadow-xl"
+            >
+              <div className="absolute inset-x-0 top-0 h-1.5 bg-gradient-to-r from-amber-500 to-orange-500" />
+              <div className="absolute right-0 top-0 h-32 w-32 rounded-bl-full bg-gradient-to-bl from-amber-500/10 to-transparent" />
+              <div className="relative">
+                <p className="text-xs font-medium uppercase tracking-widest text-amber-500">
+                  AI Company Platform
+                </p>
+                <h3 className="mt-2 text-xl font-semibold">Paperclip AI Company Setup</h3>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                  Build your AI-powered company. Agent teams, workflows, governance. Set up by the
+                  people who built the platform.
+                </p>
+                <p className="mt-4 text-sm font-medium">$5K–$15K setup + optional management</p>
+                <div className="mt-6 flex items-center gap-1 text-sm font-medium text-amber-500">
+                  View full details
+                  <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                </div>
+              </div>
+            </Link>
+          </div>
+
+          {/* Other productized services */}
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            {productizedServices.map((service) => (
+              <div
+                key={service.id}
+                className="rounded-2xl border bg-card p-8 transition-shadow hover:shadow-md"
+              >
+                <div className="mb-3 flex items-center gap-3">
+                  <h3 className="text-lg font-semibold">{service.title}</h3>
+                  <Badge variant="secondary" className="text-xs">
+                    {service.badge}
+                  </Badge>
+                </div>
+                <p className="text-sm leading-relaxed text-muted-foreground">{service.body}</p>
+                <p className="mt-3 text-sm">
+                  <span className="font-medium">Good fit for:</span>{" "}
+                  <span className="text-muted-foreground">{service.goodFor}</span>
+                </p>
+                <p className="mt-3 text-sm font-medium text-muted-foreground">{service.pricing}</p>
+              </div>
+            ))}
           </div>
         </div>
       </section>
@@ -161,9 +273,9 @@ export default function ServicesPage() {
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
           <h2 className="text-balance text-3xl font-semibold md:text-4xl">What we build</h2>
-          <div className="mt-12 divide-y">
+          <div className="mt-12 divide-y overflow-hidden rounded-2xl border bg-card">
             {services.map((service) => (
-              <div key={service.id} className="py-10 first:pt-0 last:pb-0">
+              <div key={service.id} className="p-8">
                 <h3 className="text-xl font-semibold">{service.title}</h3>
                 <p className="mt-4 leading-relaxed text-muted-foreground">{service.body}</p>
                 <p className="mt-4 text-sm">
@@ -176,112 +288,26 @@ export default function ServicesPage() {
         </div>
       </section>
 
-      {/* Dedicated Offerings */}
-      <section className="py-16 md:py-24 bg-muted/30">
-        <div className="mx-auto max-w-5xl px-6">
-          <div className="max-w-2xl">
-            <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
-              New offerings
-            </p>
-            <h2 className="mt-3 text-balance text-3xl font-semibold md:text-4xl">
-              Productized services
-            </h2>
-            <p className="mt-4 text-muted-foreground leading-relaxed">
-              Fixed scopes, clear pricing, defined timelines. Pick the one that matches where you
-              are.
-            </p>
-          </div>
-
-          {/* Dedicated landing pages */}
-          <div className="mt-12 grid gap-6 md:grid-cols-2">
-            <Link
-              href="/services/openclaw"
-              className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors"
-            >
-              <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                Dedicated offering
-              </p>
-              <h3 className="mt-2 text-xl font-semibold">OpenClaw Setup & Deployment</h3>
-              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                AI agent orchestration, deployed and running. We set up OpenClaw for businesses that
-                want multi-agent systems without spending six months on the architecture.
-              </p>
-              <p className="mt-4 text-sm font-medium">$5K–$15K project-based</p>
-              <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
-                View full details{" "}
-                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-              </div>
-            </Link>
-            <Link
-              href="/services/paperclip"
-              className="group rounded-2xl border bg-card p-8 hover:border-foreground/20 transition-colors"
-            >
-              <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                Dedicated offering
-              </p>
-              <h3 className="mt-2 text-xl font-semibold">Paperclip AI Company Setup</h3>
-              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                Build your AI-powered company. Agent teams, workflows, governance. We built
-                Paperclip — when we set you up, it's the people who made the platform doing the
-                configuration.
-              </p>
-              <p className="mt-4 text-sm font-medium">$3K–$10K setup + optional management</p>
-              <div className="mt-6 flex items-center gap-1 text-sm font-medium text-primary">
-                View full details{" "}
-                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-              </div>
-            </Link>
-          </div>
-
-          {/* Other productized services */}
-          <div className="mt-8 divide-y rounded-2xl border bg-card">
-            {productizedServices.map((service) => (
-              <div key={service.id} className="p-8 first:pt-8 last:pb-8">
-                <div className="flex flex-wrap items-start justify-between gap-4">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3">
-                      <h3 className="text-lg font-semibold">{service.title}</h3>
-                      <Badge variant="secondary" className="text-xs">
-                        {service.badge}
-                      </Badge>
-                    </div>
-                    <p className="mt-3 leading-relaxed text-muted-foreground text-sm">
-                      {service.body}
-                    </p>
-                    <p className="mt-3 text-sm">
-                      <span className="font-medium">Good fit for:</span>{" "}
-                      <span className="text-muted-foreground">{service.goodFor}</span>
-                    </p>
-                  </div>
-                  <div className="shrink-0 text-right">
-                    <p className="text-sm font-medium text-muted-foreground">{service.pricing}</p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       {/* Pricing */}
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <Card className="rounded-3xl border p-10 md:p-16">
+          <div className="relative overflow-hidden rounded-3xl border p-10 md:p-16">
+            <BorderBeam duration={20} />
             <h2 className="text-balance text-3xl font-semibold md:text-4xl">Pricing</h2>
             <div className="mt-8 max-w-2xl space-y-4 leading-relaxed text-muted-foreground">
               <p>
                 Hourly rates run $100 to $200 depending on what the work requires. Complex AI work,
                 architecture, and technical consulting sit at the higher end. Standard development
-                and integrations are in the middle. Performance work and straightforward builds are
-                at the lower end.
+                and integrations are in the middle.
               </p>
               <p>
                 Project-based pricing is available for well-defined scopes. We can talk through that
                 on the discovery call.
               </p>
               <p>
-                All projects start with a free 30-minute call. We'll tell you whether we're the
-                right fit and roughly what it would cost before anyone commits to anything.
+                All projects start with a free 30-minute call. We&apos;ll tell you whether
+                we&apos;re the right fit and roughly what it would cost before anyone commits to
+                anything.
               </p>
             </div>
             <div className="mt-10">
@@ -294,35 +320,38 @@ export default function ServicesPage() {
                 }
               />
             </div>
-          </Card>
+          </div>
         </div>
       </section>
 
       {/* Case Studies */}
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <h2 className="text-balance text-3xl font-semibold md:text-4xl">What we've built</h2>
-          <div className="mt-12 grid gap-8 md:grid-cols-3">
+          <h2 className="text-balance text-3xl font-semibold md:text-4xl">What we&apos;ve built</h2>
+          <div className="mt-12 grid gap-6 md:grid-cols-3">
             {caseStudies.map((study) => (
-              <Card key={study.id} className="flex flex-col rounded-2xl border p-8">
-                <div>
-                  <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-                    {study.subtitle}
-                  </p>
-                  <h3 className="mt-2 text-xl font-semibold">{study.title}</h3>
-                </div>
-                <div className="mt-6 space-y-4 text-sm leading-relaxed">
+              <Card key={study.id} className="flex flex-col overflow-hidden rounded-2xl border">
+                <div className={`h-2 bg-gradient-to-r ${study.gradient}`} />
+                <div className="flex flex-1 flex-col p-8">
                   <div>
-                    <p className="font-medium">Problem</p>
-                    <p className="mt-1 text-muted-foreground">{study.problem}</p>
+                    <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+                      {study.subtitle}
+                    </p>
+                    <h3 className="mt-2 text-xl font-semibold">{study.title}</h3>
                   </div>
-                  <div>
-                    <p className="font-medium">Solution</p>
-                    <p className="mt-1 text-muted-foreground">{study.solution}</p>
-                  </div>
-                  <div>
-                    <p className="font-medium">Outcome</p>
-                    <p className="mt-1 text-muted-foreground">{study.outcome}</p>
+                  <div className="mt-6 space-y-4 text-sm leading-relaxed">
+                    <div>
+                      <p className="font-medium">Problem</p>
+                      <p className="mt-1 text-muted-foreground">{study.problem}</p>
+                    </div>
+                    <div>
+                      <p className="font-medium">Solution</p>
+                      <p className="mt-1 text-muted-foreground">{study.solution}</p>
+                    </div>
+                    <div>
+                      <p className="font-medium">Outcome</p>
+                      <p className="mt-1 text-muted-foreground">{study.outcome}</p>
+                    </div>
                   </div>
                 </div>
               </Card>
@@ -334,27 +363,35 @@ export default function ServicesPage() {
       {/* CTA */}
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
-            <h2 className="text-balance text-4xl font-semibold lg:text-5xl">
-              Have something to build?
-            </h2>
-            <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
-              We keep the client list manageable. Most projects start with a 30-minute call, no
-              commitment, just a conversation about what you're trying to build and whether we're
-              the right people to help.
-            </p>
-            <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
-              <ScheduleCallModal
-                trigger={
-                  <Button size="lg">
-                    <span className="text-nowrap">Book a discovery call</span>
-                    <ChevronRight className="ml-1" />
-                  </Button>
-                }
-              />
-              <Button asChild variant="outline" size="lg">
-                <Link href={routes.contact}>Send us a message</Link>
-              </Button>
+          <div className="relative overflow-hidden rounded-3xl border bg-neutral-950 px-6 py-12 text-center md:py-20 lg:py-32">
+            <RetroGrid className="opacity-15" />
+            <div className="relative">
+              <h2 className="text-balance text-4xl font-semibold text-white lg:text-5xl">
+                Have something to build?
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-neutral-400">
+                We keep the client list manageable. Most projects start with a 30-minute call, no
+                commitment, just a conversation about what you&apos;re trying to build and whether
+                we&apos;re the right people to help.
+              </p>
+              <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+                <ScheduleCallModal
+                  trigger={
+                    <Button size="lg" className="bg-white text-black hover:bg-neutral-200">
+                      <span className="text-nowrap">Book a discovery call</span>
+                      <ChevronRight className="ml-1" />
+                    </Button>
+                  }
+                />
+                <Button
+                  asChild
+                  variant="outline"
+                  size="lg"
+                  className="border-neutral-700 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+                >
+                  <Link href={routes.contact}>Send us a message</Link>
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/(app)/(main)/services/page.tsx
+++ b/src/app/(app)/(main)/services/page.tsx
@@ -198,7 +198,7 @@ export default function ServicesPage() {
 
           <div className="mt-12 grid gap-6 md:grid-cols-2">
             <Link
-              href="/services/openclaw"
+              href={routes.servicesOpenclaw}
               className="group relative overflow-hidden rounded-2xl border bg-card p-8 transition-shadow hover:shadow-xl"
             >
               <div className="absolute inset-x-0 top-0 h-1.5 bg-gradient-to-r from-emerald-500 to-cyan-500" />
@@ -221,7 +221,7 @@ export default function ServicesPage() {
             </Link>
 
             <Link
-              href="/services/paperclip"
+              href={routes.servicesPaperclip}
               className="group relative overflow-hidden rounded-2xl border bg-card p-8 transition-shadow hover:shadow-xl"
             >
               <div className="absolute inset-x-0 top-0 h-1.5 bg-gradient-to-r from-amber-500 to-orange-500" />

--- a/src/app/(app)/(main)/services/paperclip/page.tsx
+++ b/src/app/(app)/(main)/services/paperclip/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Check, ChevronRight } from "lucide-react";
+import { ArrowLeft, Check, ChevronRight, Eye, Headphones, Layers, Users } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { ScheduleCallModal } from "@/components/modals/schedule-call-modal";
@@ -8,16 +8,47 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import AnimatedGradientText from "@/components/ui/animated-gradient-text";
+import { BorderBeam } from "@/components/ui/border-beam";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import RetroGrid from "@/components/ui/retro-grid";
+import { TextEffect } from "@/components/ui/text-effect";
 import { constructMetadata } from "@/config/metadata";
 import { routes } from "@/config/routes";
+import { PaperclipDashboard } from "../_components/paperclip-dashboard";
 
 export const metadata: Metadata = constructMetadata({
   title: "Paperclip AI Company Setup | Build And Serve",
   description:
-    "Stand up an AI-powered company with agent teams via Paperclip. Company design, agent hiring, workflow setup, and governance. $3K–$10K setup + optional management.",
+    "Stand up an AI-powered company with agent teams via Paperclip. Company design, agent hiring, workflow setup, and governance. $5K–$15K setup + optional management.",
 });
+
+const benefits = [
+  {
+    icon: Layers,
+    title: "A Real Operating System, Not Another Tool",
+    body: "Paperclip isn’t a chatbot builder or a workflow automation platform. It’s a management layer for AI agent teams — with roles, task assignment, approval chains, budgets, escalation, and oversight.",
+    gradient: "from-amber-500 to-orange-500",
+  },
+  {
+    icon: Users,
+    title: "Agents That Do Actual Work",
+    body: "Your agents write content, handle support tickets, analyze data, manage projects, and coordinate with each other on complex tasks. We configure each agent for your specific workflows.",
+    gradient: "from-orange-500 to-red-500",
+  },
+  {
+    icon: Eye,
+    title: "You Stay in Control",
+    body: "Every action an agent takes is visible, auditable, and governed by rules you set. Budget limits, approval gates, escalation paths — you decide how much autonomy your agents get.",
+    gradient: "from-red-500 to-amber-500",
+  },
+  {
+    icon: Headphones,
+    title: "60 Days of Hands-On Support",
+    body: "The first two months are when you figure out how to actually run this thing. We’re there for all of it. Adjusting agents, tuning workflows, answering the questions you didn’t know you’d have.",
+    gradient: "from-amber-500 to-yellow-500",
+  },
+];
 
 const steps = [
   {
@@ -38,26 +69,7 @@ const steps = [
   {
     number: "04",
     title: "Launch & Support",
-    body: "Your AI company goes live. We stick around for 60 days to help you manage and adjust. By the end, you're running it on your own — or you can add our managed service if you'd rather not.",
-  },
-];
-
-const benefits = [
-  {
-    title: "A Real Operating System, Not Another Tool",
-    body: "Paperclip isn't a chatbot builder or a workflow automation platform. It's a management layer for AI agent teams — with roles, task assignment, approval chains, budgets, escalation, and oversight.",
-  },
-  {
-    title: "Agents That Do Actual Work",
-    body: "Your agents write content, handle support tickets, analyze data, manage projects, and coordinate with each other on complex tasks. We configure each agent for your specific workflows.",
-  },
-  {
-    title: "You Stay in Control",
-    body: "Every action an agent takes is visible, auditable, and governed by rules you set. Budget limits, approval gates, escalation paths — you decide how much autonomy your agents get.",
-  },
-  {
-    title: "60 Days of Hands-On Support",
-    body: "The first two months are when you figure out how to actually run this thing. We're there for all of it. Adjusting agents, tuning workflows, answering the questions you didn't know you'd have.",
+    body: "Your AI company goes live. We stick around for 60 days to help you manage and adjust. By the end, you’re running it on your own — or you can add our managed service if you’d rather not.",
   },
 ];
 
@@ -112,7 +124,7 @@ const faqs = [
     id: "faq-1",
     question: 'What exactly is an "AI company"?',
     answer:
-      "It's a structured team of AI agents that operates like a real company — with defined roles, task assignments, approval workflows, budgets, and oversight. Instead of using AI as a tool, you're deploying AI as a workforce with governance.",
+      "It’s a structured team of AI agents that operates like a real company — with defined roles, task assignments, approval workflows, budgets, and oversight. Instead of using AI as a tool, you’re deploying AI as a workforce with governance.",
   },
   {
     id: "faq-2",
@@ -124,7 +136,7 @@ const faqs = [
     id: "faq-3",
     question: "How much does it cost to run the agents after setup?",
     answer:
-      "Agent operating costs depend on usage volume and which AI models your agents use. Typical monthly costs range from a few hundred dollars for light usage to a few thousand for heavy operations. We'll give you cost projections during the design phase so there are no surprises.",
+      "Agent operating costs depend on usage volume and which AI models your agents use. Typical monthly costs range from a few hundred dollars for light usage to a few thousand for heavy operations. We’ll give you cost projections during the design phase so there are no surprises.",
   },
   {
     id: "faq-4",
@@ -143,64 +155,85 @@ const faqs = [
 export default function PaperclipPage() {
   return (
     <div className="min-h-screen">
-      {/* Back nav */}
-      <div className="mx-auto max-w-5xl px-6 pt-8">
-        <Link
-          href={routes.services}
-          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          All services
-        </Link>
-      </div>
-
       {/* Hero */}
-      <section className="py-16 md:py-24">
-        <div className="mx-auto max-w-5xl px-6">
-          <div className="max-w-2xl">
-            <p className="text-sm font-medium uppercase tracking-widest text-muted-foreground">
-              Paperclip AI Company Setup
-            </p>
-            <h1 className="mt-4 text-balance text-5xl font-semibold md:text-6xl">
-              Build Your AI-Powered Company
-            </h1>
-            <p className="mt-8 max-w-xl text-balance text-lg text-muted-foreground">
-              We set up Paperclip for your business — agent teams, workflows, governance. A
-              structured AI workforce handling real tasks, managed by you.
-            </p>
-            <p className="mt-4 text-sm text-muted-foreground">
-              Setup starts at $5,000 · Optional monthly management $1K–$3K/mo
-            </p>
-            <div className="mt-10">
-              <ScheduleCallModal
-                trigger={
-                  <Button size="lg" className="h-12 rounded-full pl-5 pr-3 text-base">
-                    <span className="text-nowrap">Book a discovery call</span>
-                    <ChevronRight className="ml-1" />
-                  </Button>
-                }
-              />
+      <section className="relative overflow-hidden bg-neutral-950 pb-20 pt-8 md:pb-28">
+        <RetroGrid className="opacity-20" />
+        <div className="relative mx-auto max-w-7xl px-6">
+          <Link
+            href={routes.services}
+            className="mb-12 inline-flex items-center gap-2 text-sm text-neutral-500 transition-colors hover:text-neutral-300"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            All services
+          </Link>
+
+          <div className="lg:grid lg:grid-cols-2 lg:items-center lg:gap-16">
+            <div>
+              <AnimatedGradientText className="mb-6">
+                <span className="text-neutral-200">Paperclip AI Company Setup</span>
+              </AnimatedGradientText>
+
+              <TextEffect
+                preset="fade-in-blur"
+                speedSegment={0.3}
+                as="h1"
+                className="text-balance text-4xl font-semibold text-white sm:text-5xl md:text-6xl"
+              >
+                Build Your AI-Powered Company
+              </TextEffect>
+
+              <p className="mt-6 max-w-lg text-balance text-lg text-neutral-400">
+                We set up Paperclip for your business &mdash; agent teams, workflows, governance. A
+                structured AI workforce handling real tasks, managed by you.
+              </p>
+
+              <p className="mt-4 text-sm text-neutral-500">
+                Setup starts at $5,000 &middot; Optional monthly management $1K–$3K/mo
+              </p>
+
+              <div className="mt-8">
+                <ScheduleCallModal
+                  trigger={
+                    <Button
+                      size="lg"
+                      className="h-12 rounded-full bg-amber-600 pl-5 pr-3 text-base text-white hover:bg-amber-500"
+                    >
+                      <span className="text-nowrap">Book a discovery call</span>
+                      <ChevronRight className="ml-1" />
+                    </Button>
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="mt-12 lg:mt-0">
+              <div className="relative">
+                <div className="absolute -inset-4 rounded-2xl bg-gradient-to-br from-amber-500/20 via-transparent to-orange-500/20 blur-2xl" />
+                <PaperclipDashboard className="relative" />
+              </div>
             </div>
           </div>
         </div>
       </section>
 
       {/* Context */}
-      <section className="py-16 md:py-24 bg-muted/30">
+      <section className="bg-muted/30 py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <div className="max-w-3xl">
+          <div className="max-w-3xl border-l-2 border-amber-500/50 pl-8">
             <h2 className="text-balance text-3xl font-semibold md:text-4xl">
               Built by the People Who Built Paperclip
             </h2>
-            <div className="mt-6 space-y-4 text-muted-foreground leading-relaxed">
+            <div className="mt-6 space-y-4 leading-relaxed text-muted-foreground">
               <p>
-                Paperclip is our platform. When we set up your AI company, you're getting the team
-                that designed the system and runs their own operations on it every day. That's the
-                practical difference between a setup that works and one that needs constant fixing.
+                Paperclip is our platform. When we set up your AI company, you&apos;re getting the
+                team that designed the system and runs their own operations on it every day.
+                That&apos;s the practical difference between a setup that works and one that needs
+                constant fixing.
               </p>
               <p>
-                We're not writing reports about what you could do with AI someday. We're standing up
-                a working system with real agents doing real tasks by the time we hand it over.
+                We&apos;re not writing reports about what you could do with AI someday. We&apos;re
+                standing up a working system with real agents doing real tasks by the time we hand
+                it over.
               </p>
             </div>
           </div>
@@ -211,27 +244,36 @@ export default function PaperclipPage() {
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
           <h2 className="text-balance text-3xl font-semibold md:text-4xl">What you get</h2>
-          <div className="mt-12 grid gap-8 md:grid-cols-2">
-            {benefits.map((benefit) => (
-              <div key={benefit.title} className="space-y-3">
-                <h3 className="text-lg font-semibold">{benefit.title}</h3>
-                <p className="text-muted-foreground leading-relaxed">{benefit.body}</p>
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
+            {benefits.map((b) => (
+              <div
+                key={b.title}
+                className="group relative overflow-hidden rounded-2xl border bg-card p-8 transition-shadow hover:shadow-lg"
+              >
+                <div className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${b.gradient}`} />
+                <b.icon className="mb-4 h-10 w-10 text-amber-500/80" />
+                <h3 className="text-lg font-semibold">{b.title}</h3>
+                <p className="mt-3 leading-relaxed text-muted-foreground">{b.body}</p>
               </div>
             ))}
           </div>
-          <div className="mt-12 rounded-2xl border bg-card p-8">
-            <h3 className="font-semibold">Every engagement includes:</h3>
-            <ul className="mt-4 space-y-2">
+
+          <div className="relative mt-12 overflow-hidden rounded-2xl border bg-card p-8">
+            <BorderBeam colorFrom="#f59e0b" colorTo="#ef4444" duration={20} />
+            <h3 className="text-lg font-semibold">Every engagement includes:</h3>
+            <ul className="mt-4 grid gap-2 sm:grid-cols-2">
               {[
-                "Company design: we map your operations to an agent team structure that actually makes sense",
-                "Agent hiring and configuration for your specific workflows",
-                "Workflow setup: task routing, approval chains, escalation paths, budget controls",
-                "Governance configuration: permissions, spending limits, oversight dashboards",
+                "Company design: operations mapped to agent team structure",
+                "Agent hiring and configuration for your workflows",
+                "Task routing, approval chains, escalation paths",
+                "Governance: permissions, spending limits, oversight dashboards",
+                "Budget controls and reporting setup",
                 "Team training on managing your AI company",
-                "60 days of management support to get you past the learning curve",
+                "60 days of management support",
+                "Documentation and runbooks for your team",
               ].map((item) => (
                 <li key={item} className="flex items-start gap-3 text-sm">
-                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                  <Check className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
                   <span className="text-muted-foreground">{item}</span>
                 </li>
               ))}
@@ -240,20 +282,18 @@ export default function PaperclipPage() {
         </div>
       </section>
 
-      {/* How it works */}
-      <section className="py-16 md:py-24 bg-muted/30">
+      {/* Process */}
+      <section className="bg-muted/30 py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
           <h2 className="text-balance text-3xl font-semibold md:text-4xl">How it works</h2>
-          <div className="mt-12 space-y-0 divide-y rounded-2xl border bg-card overflow-hidden">
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
             {steps.map((step) => (
-              <div key={step.number} className="flex gap-8 p-8">
-                <p className="text-3xl font-bold text-muted-foreground/30 tabular-nums shrink-0">
+              <div key={step.number} className="rounded-2xl border bg-card p-8">
+                <span className="bg-gradient-to-br from-amber-400 to-orange-400 bg-clip-text text-4xl font-bold text-transparent">
                   {step.number}
-                </p>
-                <div>
-                  <h3 className="font-semibold text-lg">{step.title}</h3>
-                  <p className="mt-2 text-muted-foreground leading-relaxed">{step.body}</p>
-                </div>
+                </span>
+                <h3 className="mt-4 text-lg font-semibold">{step.title}</h3>
+                <p className="mt-3 leading-relaxed text-muted-foreground">{step.body}</p>
               </div>
             ))}
           </div>
@@ -270,14 +310,21 @@ export default function PaperclipPage() {
           </p>
           <div className="mt-12 grid gap-6 md:grid-cols-3">
             {packages.map((pkg) => (
-              <Card
+              <div
                 key={pkg.name}
-                className={`flex flex-col rounded-2xl p-8 ${pkg.featured ? "border-2 border-primary" : "border"}`}
+                className={`relative flex flex-col overflow-hidden rounded-2xl border p-8 ${
+                  pkg.featured
+                    ? "border-amber-500/50 shadow-[0_0_30px_-5px_rgba(245,158,11,0.15)]"
+                    : ""
+                }`}
               >
                 {pkg.featured && (
-                  <p className="mb-4 text-xs font-medium uppercase tracking-widest text-primary">
-                    Most popular
-                  </p>
+                  <>
+                    <BorderBeam colorFrom="#f59e0b" colorTo="#ef4444" size={150} duration={10} />
+                    <p className="mb-4 text-xs font-medium uppercase tracking-widest text-amber-500">
+                      Most popular
+                    </p>
+                  </>
                 )}
                 <h3 className="text-xl font-semibold">{pkg.name}</h3>
                 <div className="mt-2">
@@ -290,7 +337,7 @@ export default function PaperclipPage() {
                 <ul className="mt-6 flex-1 space-y-2">
                   {pkg.features.map((f) => (
                     <li key={f} className="flex items-start gap-2 text-sm">
-                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                      <Check className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
                       <span className="text-muted-foreground">{f}</span>
                     </li>
                   ))}
@@ -304,27 +351,27 @@ export default function PaperclipPage() {
                     }
                   />
                 </div>
-              </Card>
+              </div>
             ))}
           </div>
-          <p className="mt-6 text-sm text-muted-foreground text-center">
-            Optional monthly management: $1,000–$3,000/mo — we handle ongoing optimization, agent
-            additions, and system maintenance.
+          <p className="mt-6 text-center text-sm text-muted-foreground">
+            Optional monthly management: $1,000–$3,000/mo &mdash; we handle ongoing optimization,
+            agent additions, and system maintenance.
           </p>
         </div>
       </section>
 
       {/* FAQ */}
-      <section className="py-16 md:py-24 bg-muted/30">
+      <section className="bg-muted/30 py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <h2 className="text-balance text-3xl font-semibold md:text-4xl text-center">
+          <h2 className="text-balance text-center text-3xl font-semibold md:text-4xl">
             Common questions
           </h2>
           <div className="mx-auto mt-12 max-w-2xl">
             <Accordion
               type="single"
               collapsible
-              className="bg-card ring-muted w-full rounded-2xl border px-8 py-3 shadow-sm ring-4 dark:ring-0"
+              className="ring-muted w-full rounded-2xl border bg-card px-8 py-3 shadow-sm ring-4 dark:ring-0"
             >
               {faqs.map((faq) => (
                 <AccordionItem key={faq.id} value={faq.id} className="border-dashed">
@@ -344,27 +391,35 @@ export default function PaperclipPage() {
       {/* CTA */}
       <section className="py-16 md:py-24">
         <div className="mx-auto max-w-5xl px-6">
-          <div className="rounded-3xl border px-6 py-12 text-center md:py-20 lg:py-32">
-            <h2 className="text-balance text-4xl font-semibold lg:text-5xl">
-              Let's talk about your AI company.
-            </h2>
-            <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
-              30-minute call, no commitment. We'll discuss what your operations look like, which
-              agent roles make sense, and what the setup would involve. If Paperclip isn't the right
-              fit, we'll say so.
-            </p>
-            <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
-              <ScheduleCallModal
-                trigger={
-                  <Button size="lg">
-                    <span className="text-nowrap">Book a discovery call</span>
-                    <ChevronRight className="ml-1" />
-                  </Button>
-                }
-              />
-              <Button asChild variant="outline" size="lg">
-                <Link href={routes.contact}>Send us a message</Link>
-              </Button>
+          <div className="relative overflow-hidden rounded-3xl border bg-neutral-950 px-6 py-16 text-center md:py-24">
+            <RetroGrid className="opacity-15" />
+            <div className="relative">
+              <h2 className="text-balance text-4xl font-semibold text-white lg:text-5xl">
+                Let&apos;s talk about your AI company.
+              </h2>
+              <p className="mx-auto mt-4 max-w-xl text-neutral-400">
+                30-minute call, no commitment. We&apos;ll discuss what your operations look like,
+                which agent roles make sense, and what the setup would involve. If Paperclip
+                isn&apos;t the right fit, we&apos;ll say so.
+              </p>
+              <div className="mt-12 flex flex-wrap items-center justify-center gap-4">
+                <ScheduleCallModal
+                  trigger={
+                    <Button size="lg" className="bg-amber-600 text-white hover:bg-amber-500">
+                      <span className="text-nowrap">Book a discovery call</span>
+                      <ChevronRight className="ml-1" />
+                    </Button>
+                  }
+                />
+                <Button
+                  asChild
+                  variant="outline"
+                  size="lg"
+                  className="border-neutral-700 text-neutral-300 hover:bg-neutral-800 hover:text-white"
+                >
+                  <Link href={routes.contact}>Send us a message</Link>
+                </Button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Redesigns the **OpenClaw**, **Paperclip**, and **Services index** landing pages with distinctive visual identities, animated dashboard mockups, and modernized layouts
- Adds `openclaw-dashboard` and `paperclip-dashboard` illustration components used in hero sections
- Refreshes FAQ accordion and services cards with gradient styling and retro grid backgrounds

Builds on the initial service pages from PR #15 — this adds the visual polish and brand differentiation.

**Relates to:** LAC-1727

## Test plan
- [ ] `/services` — verify redesigned index page with gradient cards and updated layout
- [ ] `/services/openclaw` — verify hero, dashboard mockup, benefits, process, pricing, FAQ sections
- [ ] `/services/paperclip` — verify hero, dashboard mockup, benefits, process, pricing, FAQ sections
- [ ] Check responsive behavior on mobile viewports
- [ ] Verify Schedule Call modal opens from CTA buttons on each page