### PR TITLE
fix: resolve GSC indexing issues (404s, duplicate canonicals, sitemap)

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next-sitemap').IConfig} */
 export default {
   siteUrl: process.env.SITE_URL || "https://buildandserve.com",
-  generateRobotsTxt: true,
+  generateRobotsTxt: false,
   sitemapSize: 7000,
   robotsTxtOptions: {
     policies: [

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 export default {
-  siteUrl: process.env.SITE_URL || "https://www.shipkit.io",
+  siteUrl: process.env.SITE_URL || "https://buildandserve.com",
   generateRobotsTxt: true,
   sitemapSize: 7000,
   robotsTxtOptions: {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -46,7 +46,7 @@ export default function robots(): MetadataRoute.Robots {
      * Points search engines to your XML sitemap for efficient crawling
      * @see https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview
      */
-    // sitemap: `${siteConfig.url}/sitemap.xml`,
+    sitemap: `${siteConfig.url}/sitemap.xml`,
 
     /* Host Directive
      * Specifies the preferred domain version of your site

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -110,17 +110,7 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
     },
   ];
 
-  // Example pages (medium priority)
-  const exampleRoutes = Object.values(routes.examples)
-    .filter(
-      (route): route is string => typeof route === "string" && route !== routes.examples.index
-    )
-    .map((route) => ({
-      url: `${siteConfig.url}${route}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.7,
-    }));
+  // Example pages removed — these routes don't exist on buildandserve.com
 
   // Support pages (lower priority)
   const supportRoutes = [
@@ -149,7 +139,7 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
   switch (id) {
     case 0:
       // Main sitemap with static routes
-      return [...marketingRoutes, ...docRoutes, ...exampleRoutes, ...supportRoutes];
+      return [...marketingRoutes, ...docRoutes, ...supportRoutes];
     case 1: {
       // Blog posts sitemap (only when blog is enabled)
       if (process.env.NEXT_PUBLIC_HAS_BLOG !== "true") {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -60,41 +60,45 @@ export async function generateSitemaps() {
 }
 
 export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
+  // Fixed build date for static routes — only update when content actually changes.
+  // Using new Date() would signal a change on every build, wasting crawl budget.
+  const staticLastModified = new Date("2026-05-19");
+
   // Marketing pages (highest priority)
   const marketingRoutes = [
     {
       url: siteConfig.url,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "daily" as const,
       priority: 1,
     },
     {
       url: `${siteConfig.url}${routes.services}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.9,
     },
     {
       url: `${siteConfig.url}${routes.servicesOpenclaw}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.85,
     },
     {
       url: `${siteConfig.url}${routes.servicesPaperclip}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.85,
     },
     {
       url: `${siteConfig.url}${routes.features}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.9,
     },
     {
       url: `${siteConfig.url}${routes.pricing}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.9,
     },
@@ -104,31 +108,29 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
   const docRoutes = [
     {
       url: `${siteConfig.url}${routes.docs}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "daily" as const,
       priority: 0.8,
     },
   ];
 
-  // Example pages removed — these routes don't exist on buildandserve.com
-
   // Support pages (lower priority)
   const supportRoutes = [
     {
       url: `${siteConfig.url}${routes.faq}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "weekly" as const,
       priority: 0.6,
     },
     {
       url: `${siteConfig.url}${routes.terms}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "monthly" as const,
       priority: 0.4,
     },
     {
       url: `${siteConfig.url}${routes.privacy}`,
-      lastModified: new Date(),
+      lastModified: staticLastModified,
       changeFrequency: "monthly" as const,
       priority: 0.4,
     },

--- a/src/config/metadata.ts
+++ b/src/config/metadata.ts
@@ -147,6 +147,9 @@ export const constructMetadata = ({
   return {
     ...defaultMetadata,
     ...metadata,
+    // Don't inherit the root canonical — each page should declare its own or omit it.
+    // Inheriting root canonical causes all pages to claim the homepage as their canonical.
+    alternates: metadata.alternates ?? undefined,
     openGraph: {
       ...defaultOpenGraph,
       // Assign the extracted title string or fallback


### PR DESCRIPTION
## Summary

Fixes GSC-reported indexing issues for buildandserve.com.

- **404s from sitemap** — removed `/examples/*` routes that do not exist on buildandserve.com but were generated in the sitemap, causing Googlebot 404s
- **Duplicate without user-selected canonical** — `constructMetadata()` was inheriting `alternates.canonical: "https://buildandserve.com"` so every subpage declared the homepage as its canonical
- **next-sitemap.config.js wrong URL** — fallback was `https://www.shipkit.io`, changed to `https://buildandserve.com`
- **robots.ts sitemap undiscoverable** — sitemap URL was commented out, now enabled

Fixes LAC-1825