### PR TITLE
fix: add padding and loading skeleton to schedule call modal

### DIFF
--- a/src/components/modals/schedule-call-modal.tsx
+++ b/src/components/modals/schedule-call-modal.tsx
@@ -9,10 +9,25 @@ import {
     DialogClose,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
 
-const CalEmbed = dynamic(() => import('@calcom/embed-react'), { ssr: false });
+const CalEmbed = dynamic(() => import('@calcom/embed-react'), {
+    ssr: false,
+    loading: () => (
+        <div className="flex flex-col items-center justify-center gap-4 p-6 w-full min-h-[400px]">
+            <Skeleton className="h-8 w-48" />
+            <div className="grid grid-cols-7 gap-2 w-full max-w-md">
+                {Array.from({ length: 35 }).map((_, i) => (
+                    <Skeleton key={i} className="h-10 w-full rounded-md" />
+                ))}
+            </div>
+            <Skeleton className="h-16 w-full max-w-md" />
+        </div>
+    ),
+});
 
 export function ScheduleCallModal({ trigger }: { trigger: React.ReactNode }) {
     const isMobile = useMediaQuery("(max-width: 768px)");
@@ -26,13 +41,13 @@ export function ScheduleCallModal({ trigger }: { trigger: React.ReactNode }) {
                     : 'max-w-4xl'
                     } p-0 max-h-[85vh] flex flex-col`}
             >
-                <DialogHeader className={`${isMobile ? 'px-4 py-2' : ''}`}>
+                <DialogHeader className="px-6 pt-6 pb-3">
                     <DialogTitle className={`${isMobile ? 'text-sm' : ''}`}>
                         Schedule a Call
                     </DialogTitle>
                 </DialogHeader>
                 <div
-                    className={`w-full flex-1 overflow-y-auto ${isMobile
+                    className={`w-full flex-1 overflow-y-auto min-h-0 ${isMobile
                         ? '[&::-webkit-scrollbar]:hidden [-webkit-overflow-scrolling:touch]'
                         : ''
                         }`}
@@ -42,21 +57,33 @@ export function ScheduleCallModal({ trigger }: { trigger: React.ReactNode }) {
                         msOverflowStyle: 'none'
                     } : {}}
                 >
-                    <CalEmbed
-                        calLink="lacymorrow/dev"
-                        className="w-full h-full"
-                        style={{
-                            width: '100%',
-                            height: '100%',
-                            minHeight: '400px'
-                        }}
-                        config={{
-                            layout: isMobile ? 'week_view' : 'month_view',
-                            theme: 'auto',
-                        }}
-                    />
+                    <Suspense fallback={
+                        <div className="flex flex-col items-center justify-center gap-4 p-6 w-full min-h-[400px]">
+                            <Skeleton className="h-8 w-48" />
+                            <div className="grid grid-cols-7 gap-2 w-full max-w-md">
+                                {Array.from({ length: 35 }).map((_, i) => (
+                                    <Skeleton key={i} className="h-10 w-full rounded-md" />
+                                ))}
+                            </div>
+                            <Skeleton className="h-16 w-full max-w-md" />
+                        </div>
+                    }>
+                        <CalEmbed
+                            calLink="lacymorrow/dev"
+                            className="w-full h-full"
+                            style={{
+                                width: '100%',
+                                height: '100%',
+                                minHeight: '400px'
+                            }}
+                            config={{
+                                layout: isMobile ? 'week_view' : 'month_view',
+                                theme: 'auto',
+                            }}
+                        />
+                    </Suspense>
                 </div>
-                <DialogFooter className={`${isMobile ? 'px-4 py-2' : ''}`}>
+                <DialogFooter className="px-6 pb-6 pt-3">
                     <DialogClose asChild>
                         <Button variant="outline" size={isMobile ? 'sm' : 'default'}>
                             Close


### PR DESCRIPTION
## Summary

- Added `px-6 pt-6 pb-3` padding to `DialogHeader` and `px-6 pb-6 pt-3` to `DialogFooter` so the title and close button are no longer squished against the modal edges
- Added a skeleton calendar grid as both the `dynamic()` loading state and a `<Suspense>` fallback to eliminate the flash of unstyled content while the cal.com widget initializes
- Added `min-h-0` to the scrollable content area for proper flex overflow

## Test plan

- [ ] Open the "Schedule a Call" modal — verify title and close button have visible padding from modal edges
- [ ] Observe the skeleton loading state appears briefly before cal.com widget renders (no flash of unstyled content)
- [ ] Test on mobile viewport — modal still fills screen properly with padding intact