### PR TITLE
fix: prevent leading whitespace on wrapped TextEffect headings

### DIFF
--- a/src/components/ui/text-effect.tsx
+++ b/src/components/ui/text-effect.tsx
@@ -151,7 +151,7 @@ const AnimationComponent: React.FC<{
     return content;
   }
 
-  const defaultWrapperClassName = per === 'line' ? 'block' : 'inline-block';
+  const defaultWrapperClassName = per === 'line' ? 'block' : (isWhitespace ? '' : 'inline-block');
 
   return (
     <span className={cn(defaultWrapperClassName, segmentWrapperClassName)}>

--- a/src/components/ui/text-effect.tsx
+++ b/src/components/ui/text-effect.tsx
@@ -117,6 +117,8 @@ const AnimationComponent: React.FC<{
   per: 'line' | 'word' | 'char';
   segmentWrapperClassName?: string;
 }> = React.memo(({ segment, variants, per, segmentWrapperClassName }) => {
+  const isWhitespace = per === 'word' && !segment.trim();
+
   const content =
     per === 'line' ? (
       <motion.span variants={variants} className='block'>
@@ -126,7 +128,7 @@ const AnimationComponent: React.FC<{
       <motion.span
         aria-hidden='true'
         variants={variants}
-        className='inline-block whitespace-pre'
+        className={isWhitespace ? 'whitespace-pre' : 'inline-block whitespace-pre'}
       >
         {segment}
       </motion.span>


### PR DESCRIPTION
## Summary

- Fixes the visual text spacing issue on the OpenClaw service page where "Teams" appeared indented when the hero heading wrapped to a new line
- Root cause: `TextEffect` component wraps every segment (including whitespace between words) in `inline-block` spans, which prevents normal line-break whitespace collapsing
- Fix: whitespace-only segments now render without `inline-block`, allowing the browser to collapse them at line breaks as expected

## Test plan

- [ ] Verify the OpenClaw hero heading wraps cleanly at all viewport widths without leading whitespace on new lines
- [ ] Verify other pages using `TextEffect` still animate and display correctly
- [ ] Check mobile and desktop breakpoints

Fixes LAC-1844