### PR TITLE
fix: prevent orphan words in hero headings with text-wrap balance

### DIFF
--- a/src/app/(app)/(main)/services/openclaw/page.tsx
+++ b/src/app/(app)/(main)/services/openclaw/page.tsx
@@ -122,7 +122,7 @@ export default function OpenClawPage() {
               <p className="text-xs font-medium uppercase tracking-[0.2em] text-emerald-400/80">
                 AI Agent Orchestration
               </p>
-              <h1 className="mt-4 text-4xl font-medium tracking-tight text-white sm:text-5xl">
+              <h1 className="mt-4 text-balance text-4xl font-medium tracking-tight text-white sm:text-5xl">
                 Deploy AI Agent Teams That Actually Work
               </h1>
               <p className="mt-6 max-w-lg text-lg leading-relaxed text-neutral-400">

--- a/src/app/(app)/(main)/services/page.tsx
+++ b/src/app/(app)/(main)/services/page.tsx
@@ -125,7 +125,7 @@ export default function ServicesPage() {
       {/* Hero */}
       <section className="pb-16 pt-24 md:pb-20 md:pt-36">
         <div className="mx-auto max-w-5xl px-6">
-          <h1 className="max-w-3xl text-4xl font-medium tracking-tight md:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
+          <h1 className="max-w-3xl text-balance text-4xl font-medium tracking-tight md:text-5xl lg:text-[3.5rem] lg:leading-[1.1]">
             We handle the technical side.{" "}
             <span className="text-muted-foreground">
               You focus on everything else.

--- a/src/app/(app)/(main)/services/paperclip/page.tsx
+++ b/src/app/(app)/(main)/services/paperclip/page.tsx
@@ -124,7 +124,7 @@ export default function PaperclipPage() {
             <p className="text-xs font-medium uppercase tracking-[0.2em] text-amber-400/80">
               AI Company Platform
             </p>
-            <h1 className="mt-4 text-4xl font-medium tracking-tight text-white sm:text-5xl md:text-[3.5rem] md:leading-[1.1]">
+            <h1 className="mt-4 text-balance text-4xl font-medium tracking-tight text-white sm:text-5xl md:text-[3.5rem] md:leading-[1.1]">
               Build Your AI-Powered Company
             </h1>
             <p className="mt-6 text-lg leading-relaxed text-neutral-400">

--- a/src/components/ui/text-effect.tsx
+++ b/src/components/ui/text-effect.tsx
@@ -116,8 +116,10 @@ const AnimationComponent: React.FC<{
   variants: Variants;
   per: 'line' | 'word' | 'char';
   segmentWrapperClassName?: string;
-}> = React.memo(({ segment, variants, per, segmentWrapperClassName }) => {
+  animationComplete?: boolean;
+}> = React.memo(({ segment, variants, per, segmentWrapperClassName, animationComplete }) => {
   const isWhitespace = per === 'word' && !segment.trim();
+  const wordDisplay = isWhitespace || animationComplete ? 'whitespace-pre' : 'inline-block whitespace-pre';
 
   const content =
     per === 'line' ? (
@@ -128,18 +130,18 @@ const AnimationComponent: React.FC<{
       <motion.span
         aria-hidden='true'
         variants={variants}
-        className={isWhitespace ? 'whitespace-pre' : 'inline-block whitespace-pre'}
+        className={wordDisplay}
       >
         {segment}
       </motion.span>
     ) : (
-      <motion.span className='inline-block whitespace-pre'>
+      <motion.span className={animationComplete ? 'whitespace-pre' : 'inline-block whitespace-pre'}>
         {segment.split('').map((char, charIndex) => (
           <motion.span
             key={`char-${charIndex}`}
             aria-hidden='true'
             variants={variants}
-            className='inline-block whitespace-pre'
+            className={animationComplete ? 'whitespace-pre' : 'inline-block whitespace-pre'}
           >
             {char}
           </motion.span>
@@ -151,7 +153,7 @@ const AnimationComponent: React.FC<{
     return content;
   }
 
-  const defaultWrapperClassName = per === 'line' ? 'block' : (isWhitespace ? '' : 'inline-block');
+  const defaultWrapperClassName = per === 'line' ? 'block' : (isWhitespace || animationComplete ? '' : 'inline-block');
 
   return (
     <span className={cn(defaultWrapperClassName, segmentWrapperClassName)}>
@@ -226,6 +228,7 @@ export function TextEffect({
   segmentTransition,
   style,
 }: TextEffectProps) {
+  const [animationComplete, setAnimationComplete] = React.useState(!trigger);
   const segments = splitText(children, per);
   const MotionTag = motion[as as keyof typeof motion] as typeof motion.div;
 
@@ -275,7 +278,10 @@ export function TextEffect({
           exit='exit'
           variants={computedVariants.container}
           className={className}
-          onAnimationComplete={onAnimationComplete}
+          onAnimationComplete={() => {
+            setAnimationComplete(true);
+            onAnimationComplete?.();
+          }}
           onAnimationStart={onAnimationStart}
           style={style}
         >
@@ -287,6 +293,7 @@ export function TextEffect({
               variants={computedVariants.item}
               per={per}
               segmentWrapperClassName={segmentWrapperClassName}
+              animationComplete={animationComplete}
             />
           ))}
         </MotionTag>


### PR DESCRIPTION
## Summary
- TextEffect component removes inline-block from word spans after animation completes, allowing text-wrap balance to prevent orphan words
- Adds text-balance to service page H1s missing it after the redesign

## Test plan
- Visit /services/openclaw at various widths - H1 should not have single word orphans
- Verify fade-in-blur animation still works on homepage hero
- Check /services and /services/paperclip hero headings