### PR TITLE
fix: prevent header overlap on legal pages (LAC-2250)

### DIFF
--- a/src/app/(app)/(main)/(legal)/layout.tsx
+++ b/src/app/(app)/(main)/(legal)/layout.tsx
@@ -1,0 +1,5 @@
+import type React from "react";
+
+export default function LegalLayout({ children }: { children: React.ReactNode }) {
+	return <div className="pt-24 md:pt-36">{children}</div>;
+}


### PR DESCRIPTION
## Summary
- Fixes [LAC-2250](https://paperclip.so/LAC/issues/LAC-2250) — the fixed header was overlapping page content on `/privacy-policy`, `/terms-of-service`, `/eula`, and `/legal`.
- Root cause: those routes render MDX through the shared wrapper (`src/mdx-components.tsx`) which uses only `py-10`. The header is `position: fixed` so content directly under it needs ~`pt-24`/`pt-36` of clearance, like `/services` uses.
- Adds a `(legal)/layout.tsx` route-group layout that applies `pt-24 md:pt-36` to all four legal pages — narrow blast radius, no impact on other MDX pages or the home hero.

## Test plan
- [x] `curl /privacy-policy` returns 200 with the `pt-24 md:pt-36` wrapper rendered around the MDX content.
- [ ] Visual check: header no longer overlaps the "Privacy Policy" heading at mobile + desktop widths.
- [ ] Spot-check `/terms-of-service`, `/eula`, `/legal` — all share the layout.
- [ ] Other MDX-less pages (`/`, `/services`, `/faq`, `/contact`) unaffected.