### PR TITLE
fix: hero text no-wrap regression from TextEffect whitespace-pre

### DIFF
--- a/src/components/ui/text-effect.tsx
+++ b/src/components/ui/text-effect.tsx
@@ -119,7 +119,7 @@ const AnimationComponent: React.FC<{
   animationComplete?: boolean;
 }> = React.memo(({ segment, variants, per, segmentWrapperClassName, animationComplete }) => {
   const isWhitespace = per === 'word' && !segment.trim();
-  const wordDisplay = isWhitespace || animationComplete ? 'whitespace-pre' : 'inline-block whitespace-pre';
+  const wordDisplay = animationComplete ? '' : (isWhitespace ? 'whitespace-pre' : 'inline-block whitespace-pre');
 
   const content =
     per === 'line' ? (
@@ -135,13 +135,13 @@ const AnimationComponent: React.FC<{
         {segment}
       </motion.span>
     ) : (
-      <motion.span className={animationComplete ? 'whitespace-pre' : 'inline-block whitespace-pre'}>
+      <motion.span className={animationComplete ? '' : 'inline-block whitespace-pre'}>
         {segment.split('').map((char, charIndex) => (
           <motion.span
             key={`char-${charIndex}`}
             aria-hidden='true'
             variants={variants}
-            className={animationComplete ? 'whitespace-pre' : 'inline-block whitespace-pre'}
+            className={animationComplete ? '' : 'inline-block whitespace-pre'}
           >
             {char}
           </motion.span>


### PR DESCRIPTION
## Summary

- **Fixes regression from PR #23** where hero heading text stretches across the full viewport width, rendering behind the hero image instead of wrapping
- Root cause: after animation completes, all TextEffect word spans retained `whitespace-pre` class (`white-space: pre`), which prevents all line wrapping
- Fix: after animation completes, spans get no special class — normal inline flow handles wrapping correctly with `text-wrap: balance`

## Test plan

- [x] Verified locally: homepage hero heading wraps properly within its column after animation completes
- [x] Services page heading also wraps correctly
- [ ] Verify on production after deploy that hero text no longer stretches behind the hero image