### PR TITLE
fix: eliminate layout shift in TextEffect after animation completes

### DIFF
--- a/src/components/ui/text-effect.tsx
+++ b/src/components/ui/text-effect.tsx
@@ -119,7 +119,9 @@ const AnimationComponent: React.FC<{
   animationComplete?: boolean;
 }> = React.memo(({ segment, variants, per, segmentWrapperClassName, animationComplete }) => {
   const isWhitespace = per === 'word' && !segment.trim();
-  const wordDisplay = animationComplete ? '' : (isWhitespace ? 'whitespace-pre' : 'inline-block whitespace-pre');
+  const wordDisplay = isWhitespace
+    ? 'whitespace-pre'
+    : (animationComplete ? 'inline-block' : 'inline-block whitespace-pre');
 
   const content =
     per === 'line' ? (
@@ -135,13 +137,13 @@ const AnimationComponent: React.FC<{
         {segment}
       </motion.span>
     ) : (
-      <motion.span className={animationComplete ? '' : 'inline-block whitespace-pre'}>
+      <motion.span className={animationComplete ? 'inline-block' : 'inline-block whitespace-pre'}>
         {segment.split('').map((char, charIndex) => (
           <motion.span
             key={`char-${charIndex}`}
             aria-hidden='true'
             variants={variants}
-            className={animationComplete ? '' : 'inline-block whitespace-pre'}
+            className={animationComplete ? 'inline-block' : 'inline-block whitespace-pre'}
           >
             {char}
           </motion.span>
@@ -153,7 +155,7 @@ const AnimationComponent: React.FC<{
     return content;
   }
 
-  const defaultWrapperClassName = per === 'line' ? 'block' : (isWhitespace || animationComplete ? '' : 'inline-block');
+  const defaultWrapperClassName = per === 'line' ? 'block' : (isWhitespace ? '' : 'inline-block');
 
   return (
     <span className={cn(defaultWrapperClassName, segmentWrapperClassName)}>


### PR DESCRIPTION
## Summary

- **Fixes layout shift** reported after PR #25 where hero text visibly jumps/reflows when the TextEffect animation completes
- Root cause: PR #25 changed word spans from `inline-block` to plain `inline` after animation, causing a display-mode change that triggers text reflow (especially with `text-wrap: balance`)
- Fix: keep `inline-block` on word spans throughout — only remove `whitespace-pre` after animation. Since the display mode never changes, there's zero reflow/layout shift
- Tradeoff: `text-wrap: balance` won't take effect while TextEffect spans are active (inline-block children prevent it), but text wraps naturally between inline-block boxes

## Test plan

- [ ] Verify hero heading on homepage has no visible layout shift after animation completes
- [ ] Verify text still wraps properly (no full-width stretching)
- [ ] Verify spacing between words is preserved